### PR TITLE
VM-CdDrive-Report

### DIFF
--- a/PowerActions/VM-CdDrive-Report.ps1
+++ b/PowerActions/VM-CdDrive-Report.ps1
@@ -1,5 +1,6 @@
 <#
 .MYNGC_REPORT
+KEY\(VM\)
 .LABEL
 VM CD-Drive Report
 .DESCRIPTION

--- a/PowerActions/VM-CdDrive-Report.ps1
+++ b/PowerActions/VM-CdDrive-Report.ps1
@@ -1,0 +1,52 @@
+<#
+.MYNGC_REPORT
+#>
+
+# AUTHOR:    Aaron Smith (@awsmith99)
+# VERSION:   1.0
+# PUBLISHED: 2016.07.29
+# ABOUT    : PowerActions Report Script that reports on VMs CD-Drive configuration, making it easy
+#            to find VMs holding onto ISOs that you need to update, or VMs that can't vMotion
+#            because they are tied into a physical resource from the ESXi host that is running it.
+#            VM object is key (as it's the first managed object in the output), enabling you the
+#            ability to right-click an entry in the report to edit the target VM.  Script is able
+#            to report on VMs with multiple CD-Drives as well.
+
+param
+(
+   [Parameter(Mandatory=$true)]
+   [VMware.VimAutomation.ViCore.Types.V1.Inventory.Cluster]
+   $vParam
+);
+
+[Array] $vmList = @( Get-VM -Location $vParam | Sort Name );
+
+foreach ( $vmItem in $vmList )
+{
+    [Array] $vmCdDriveList = @( Get-CDDrive -VM $vmItem );
+
+    foreach ( $vmCdDriveItem in $vmCdDriveList )
+    {
+        [String] $insertedElement = "";
+        [String] $connectionType  = "";
+
+        switch ( $vmCdDriveItem )
+        {
+            { $_.IsoPath      } { $insertedElement = $_.IsoPath;      $connectionType = "ISO";           break; }
+            { $_.HostDevice   } { $insertedElement = $_.HostDevice;   $connectionType = "Host Device";   break; }
+            { $_.RemoteDevice } { $insertedElement = $_.RemoteDevice; $connectionType = "Remote Device"; break; }
+            default             { $insertedElement = "None";          $connectionType = "Client Device"; break; }
+        }
+
+        $output = New-Object -TypeName PSObject;
+
+        $output | Add-Member -MemberType NoteProperty -Name "VM"                -Value $vmItem
+        $output | Add-Member -MemberType NoteProperty -Name "CD-Drive"          -Value $vmCdDriveItem.Name;
+        $output | Add-Member -MemberType NoteProperty -Name "Connection"        -Value $connectionType;
+        $output | Add-Member -MemberType NoteProperty -Name "Inserted"          -Value $insertedElement;
+        $output | Add-Member -MemberType NoteProperty -Name "Connected"         -Value $vmCdDriveItem.ConnectionState.Connected;
+        $output | Add-Member -MemberType NoteProperty -Name "StartConnected"    -Value $vmCdDriveItem.ConnectionState.StartConnected;
+        $output | Add-Member -MemberType NoteProperty -Name "AllowGuestControl" -Value $vmCdDriveItem.ConnectionState.AllowGuestControl;
+        $output;
+    }
+}

--- a/PowerActions/VM-CdDrive-Report.ps1
+++ b/PowerActions/VM-CdDrive-Report.ps1
@@ -1,16 +1,14 @@
 <#
 .MYNGC_REPORT
+.LABEL
+VM CD-Drive Report
+.DESCRIPTION
+PowerActions Report Script that reports on VMs CD-Drive configuration, making it easy to find VMs holding onto ISOs that you 
+need to update, or VMs that can't vMotion because they are tied into a physical resource from the ESXi host that is running it.
+VM object is key (as it's the first managed object in the output), enabling you the ability to right-click an entry in the 
+report to edit the target VM.  Script is able to report on VMs with multiple CD-Drives as well.  Version 1.0, written by
+Aaron Smith (@awsmith99), published 07/29/2016.
 #>
-
-# AUTHOR:    Aaron Smith (@awsmith99)
-# VERSION:   1.0
-# PUBLISHED: 2016.07.29
-# ABOUT    : PowerActions Report Script that reports on VMs CD-Drive configuration, making it easy
-#            to find VMs holding onto ISOs that you need to update, or VMs that can't vMotion
-#            because they are tied into a physical resource from the ESXi host that is running it.
-#            VM object is key (as it's the first managed object in the output), enabling you the
-#            ability to right-click an entry in the report to edit the target VM.  Script is able
-#            to report on VMs with multiple CD-Drives as well.
 
 param
 (


### PR DESCRIPTION
1.0 PowerActions report script for Cluster objects.  Reports on status
of all VM's CD-Drives, making it easy to find VMs connected to a given
ISO or that might be using a physical ESXI host drive and unable to
vMotion.