### PR TITLE
Add a new VI Property: KMSserver for VM

### DIFF
--- a/Modules/VMware.VMEncryption/VMware.VMEncryption.psm1
+++ b/Modules/VMware.VMEncryption/VMware.VMEncryption.psm1
@@ -67,8 +67,8 @@ New-VIProperty -Name KMSserver -ObjectType VirtualMachine -Value {
     } -BasedOnExtensionProperty 'Config.KeyId' -Force | Out-Null
 
 New-VIProperty -Name Encrypted -ObjectType HardDisk -Value {
- Param ($hardDisk)
-     $hardDisk.ExtensionData.Backing.KeyId -ne $null
+    Param ($hardDisk)
+    $hardDisk.ExtensionData.Backing.KeyId -ne $null
 } -BasedOnExtensionProperty 'Backing.KeyId' -Force | Out-Null
 
 New-VIProperty -Name EncryptionKeyId -ObjectType HardDisk -Value {

--- a/Modules/VMware.VMEncryption/VMware.VMEncryption.psm1
+++ b/Modules/VMware.VMEncryption/VMware.VMEncryption.psm1
@@ -59,6 +59,13 @@ New-VIProperty -Name Locked -ObjectType VirtualMachine -Value  {
     ($vm.extensiondata.Runtime.ConnectionState -eq "invalid") -and ($vm.extensiondata.Config.KeyId)
 } -BasedOnExtensionProperty 'Runtime.ConnectionState','Config.KeyId' -Force | Out-Null
 
+New-VIProperty -Name KMSserver -ObjectType VirtualMachine -Value {
+    Param ($VM)
+    if ($VM.Encrypted) {
+      $VM.EncryptionKeyId.ProviderId.Id
+    }
+    } -BasedOnExtensionProperty 'Config.KeyId' -Force | Out-Null
+
 New-VIProperty -Name Encrypted -ObjectType HardDisk -Value {
  Param ($hardDisk)
      $hardDisk.ExtensionData.Backing.KeyId -ne $null


### PR DESCRIPTION
As Mike suggested, this new property will help customers to identify the VM associated KMS very easily; Also fixed a tiny issue of identation.