### PR TITLE
Improved searching for Host and Clusters, Resource Pools and Access G…

### DIFF
--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -6910,19 +6910,22 @@ function Find-HVMachine {
       $query.Filter = $andFilter
     }
     $machineList = @()
+    $GetNext = $false
     $queryResults = $query_service_helper.QueryService_Create($services, $query)
     do {
-      if ($machineList.length -ne 0) { $queryResults = $query_service_helper.QueryService_GetNext($services, $queryResults.id) }
+      if ($GetNext) { $queryResults = $query_service_helper.QueryService_GetNext($services, $queryResults.id) }
       $machineList += $queryResults.results
+      $GetNext = $true
     } while ($queryResults.remainingCount -gt 0)
     $query_service_helper.QueryService_Delete($services, $queryResults.id)
   }
   if ($wildcard -or [string]::IsNullOrEmpty($machineList)) {
     $query.Filter = $null
     $machineList = @()
+    $GetNext = $false
     $queryResults = $query_service_helper.QueryService_Create($services,$query)
     do {
-      if ($machineList.length -ne 0) { $queryResults = $query_service_helper.QueryService_GetNext($services, $queryResults.id) }
+      if ($GetNext) { $queryResults = $query_service_helper.QueryService_GetNext($services, $queryResults.id) }
       $strFilterSet = @()
       foreach ($setting in $machineSelectors.Keys) {
         if ($null -ne $params[$setting]) {
@@ -6936,6 +6939,7 @@ function Find-HVMachine {
       $whereClause =  [string]::Join(' -and ', $strFilterSet)
       $scriptBlock = [Scriptblock]::Create($whereClause)
       $machineList += $queryResults.results | where $scriptBlock
+      $GetNext = $true
     } while ($queryResults.remainingCount -gt 0)
     $query_service_helper.QueryService_Delete($services, $queryResults.id)
   }

--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -5965,8 +5965,8 @@ function Set-HVPool {
       }
       if ($desktopPools) {
         foreach ($desktopObj in $desktopPools) {
-          if (($Start -or $Stop) -and ("AUTOMATED" -ne $item.DesktopSummaryData.Type)) {
-            Write-Error "Start/Stop operation is not supported for Poll with name : [$item.DesktopSummaryData.Name]"
+          if (($Start -or $Stop) -and ("AUTOMATED" -ne $desktopObj.DesktopSummaryData.Type)) {
+            Write-Error "Start/Stop operation is not supported for Pool with name : [$desktopObj.DesktopSummaryData.Name]"
             return
           }
           $poolList.add($desktopObj.id, $desktopObj.DesktopSummaryData.Name)
@@ -5999,9 +5999,9 @@ function Set-HVPool {
       }
     }
     $updates = @()
-    if ($key -and $value) {
+    if ($PSBoundParameters.ContainsKey("key") -and $PSBoundParameters.ContainsKey("value")) {
       $updates += Get-MapEntry -key $key -value $value
-    } elseif ($key -or $value) {
+    } elseif ($PSBoundParameters.ContainsKey("key") -or $PSBoundParameters.ContainsKey("value")) {
       Write-Error "Both key:[$key] and value:[$value] needs to be specified"
     }
     if ($spec) {


### PR DESCRIPTION
…roups

Add three new internal functions Get-HVHostOrClusterID, Get-HVResourcePoolID and Get-HVAccessGroupID to search the tree results of HostOrCluster_GetHostOrClusterTree(), ResourcePool_GetResourcePoolTree() and AccessGroup_List() respectively.  Previously only the top level of the result tree from these calls where considered which was raised as issue #67 and #88 .  The solutions provided in the discussions were point fixes as they changed the level of the tree which was searched which missed matches at the other and the original levels.