### PR TITLE
Multipath to Round Robin on all FC disks in cluster

### DIFF
--- a/Scripts/SetClusterMultiPathToRoundRobin.ps1
+++ b/Scripts/SetClusterMultiPathToRoundRobin.ps1
@@ -2,28 +2,22 @@
  Script name: SetClusterMultiPathToRoundRobin.ps1
  Created on: 09/14/2017
  Author: Alan Comstock, @Mr_Uptime
- Description: Set the MultiPath policy for FC devices to RoundRobin for all hosts in a cluster.
+ Description: Set the MultiPath policy for FC devices to RoundRobin and IOPS to 1 for all hosts in a cluster based upon the vendor tag.
  Dependencies: None known
  PowerCLI Version: VMware PowerCLI 6.5 Release 1 build 4624819
  PowerShell Version: 5.1.14393.1532
  OS Version: Windows 10
 #>
 
-#Check for any Fibre Channel devices that are not set to Round Robin in a cluster.
-#Get-Cluster -Name CLUSTERNAME | Get-VMhost | Get-VMHostHba -Type "FibreChannel" | Get-ScsiLun -LunType disk | Where { $_.MultipathPolicy -notlike "RoundRobin" } | Select CanonicalName,MultipathPolicy
-
-#Set the Multipathing Policy to Round Robin for any Fibre Channel devices that are not Round Robin in a cluster
-$cluster = Get-Cluster CLUSTERNAME
-$hostlist = Get-VMHost -Location $cluster | Sort Name
-$TotalHostCount = $hostlist.count
-$hostincrement = 0
-while ($hostincrement -lt $TotalHostCount){		#Host Loop
-	$currenthost = $hostlist[$hostincrement].Name
-	Write-Host "Working on" $currenthost
-	$scsilun = Get-VMhost $currenthost | Get-VMHostHba -Type "FibreChannel" | Get-ScsiLun -LunType disk | Where { $_.MultipathPolicy -notlike "RoundRobin" }
+$pathpolicy="RoundRobin"
+$iops="1"
+$vendor="3PARdata"
+$AllESXHosts = Get-VMHost -Location CLUSTERNAME | Sort Name
+Foreach ($esxhost in $AllESXHosts) {
+	Write-Host "Working on" $esxhost
+	$scsilun = Get-VMhost $esxhost | Get-VMHostHba -Type "FibreChannel" | Get-ScsiLun -LunType disk | Where-Object {$_.Vendor -like $vendor -and ($_.MultipathPolicy -notlike $pathpolicy -or $_.CommandsToSwitchPath -ne $iops)}
 	if ($scsilun -ne $null){
-		Set-ScsiLun -ScsiLun $scsilun -MultipathPolicy RoundRobin	
+		Set-ScsiLun -ScsiLun $scsilun -MultipathPolicy $pathpolicy -CommandsToSwitchPath $iops	
 	}
-	$hostincrement++	#bump the host increment
 }
 #The End


### PR DESCRIPTION
This will configure multipath to round robin and IOPS to 1 on all disks in a cluster based upon the vendor type.
This script is configured for 3par LUNs.  Change $vendor for other storage types/vendors.

Better coding on 10/27/17 edit :)