### PR TITLE
Verbiage for DeleteFromDisk if False

### DIFF
--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -10171,7 +10171,7 @@ $deleteSpec.DeleteFromDisk = $DeleteFromDisk
 $deleteSpec.ArchivePersistentDisk = $false
 
 #Delete the machines
-write-host "Attempting to Delete:"
+if($DeleteFromDisk){write-host "Attempting to Delete:"}else{write-host "Attempting to remove from inventory:"}
 Write-Output ($deleteMachine.base.Name -join "`n")
 $bye = $machineService.Machine_DeleteMachines($services,$deleteMachine.id,$deleteSpec)
 


### PR DESCRIPTION
When using the Remove-HVMachine function, If $DeleteFromDisk is false the output should say something to the effect of "Attempting to remove from Inventory", instead of deleting the VM.