### PR TITLE
Set-HVApplicationIcon not behaving correctly with .ico and .bmp files

### DIFF
--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -8819,6 +8819,16 @@ function Set-HVApplicationIcon {
   }
 
   process {
+	if (!(Test-Path $IconPath)) {
+      Write-Error "File:[$IconPath] does not exist."
+      break
+    }
+
+    if ([IO.Path]::GetExtension($IconPath) -ne '.png') {
+      Write-Error "Unsupported file format:[$IconPath]. Only PNG image files are supported."
+      break
+    }
+
     try {
       $appInfo = Get-HVQueryResult -EntityType ApplicationInfo -Filter (Get-HVQueryFilter data.name -Eq $ApplicationName) -HvServer $HvServer
     } catch {
@@ -8829,11 +8839,6 @@ function Set-HVApplicationIcon {
 
     if ($null -eq $appInfo) {
       Write-Error "No application found with specified name:[$ApplicationName]."
-      break
-    }
-
-    if (!(Test-Path $IconPath)) {
-      Write-Error "File:[$IconPath] does not exists"
       break
     }
 


### PR DESCRIPTION
When bmp/ico image files are used as customized application icons, short
cuts feature on Horizon Client is facing the issues in rendering. Bug
2168320 has been reported for this issue. We have decided to block all
the non-png image files for the customization of application icons.

Testing:
Tested with the changes. Working as expected. Refer review
https://reviewboard.eng.vmware.com/r/1446121 for more details.