### PR TITLE
Address Issue #269

### DIFF
--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -3667,13 +3667,19 @@ function New-HVPool {
     # flashSettings
     #desktopSpec.desktopSettings.flashSettings.quality
     [Parameter(Mandatory = $false,ParameterSetName = "LINKED_CLONE")]
+    [Parameter(Mandatory = $false,ParameterSetName = 'INSTANT_CLONE')]
+    [Parameter(Mandatory = $false,ParameterSetName = 'FULL_CLONE')]
+    [Parameter(Mandatory = $false,ParameterSetName = 'MANUAL')]
     [ValidateSet('NO_CONTROL', 'LOW', 'MEDIUM', 'HIGH')]
-    [string]$quality = 'NO_CONTROL',
+    [string]$Quality = 'NO_CONTROL',
 
     #desktopSpec.desktopSettings.flashSettings.throttling
     [Parameter(Mandatory = $false,ParameterSetName = "LINKED_CLONE")]
+    [Parameter(Mandatory = $false,ParameterSetName = 'INSTANT_CLONE')]
+    [Parameter(Mandatory = $false,ParameterSetName = 'FULL_CLONE')]
+    [Parameter(Mandatory = $false,ParameterSetName = 'MANUAL')]
     [ValidateSet('DISABLED', 'CONSERVATIVE', 'MODERATE', 'AGGRESSIVE')]
-    [string]$throttling = 'DISABLED',
+    [string]$Throttling = 'DISABLED',
 
     #mirageConfigurationOverrides
     #desktopSpec.desktopSettings.mirageConfigurationOverrides.overrideGlobalSetting


### PR DESCRIPTION
Both flash parameters for `New-HVPool` were limited to the validate set of `LINKED_CLONE`. This updates them to be valid for all desktop types, since it is applicable to all desktop types. See https://vdc-download.vmware.com/vmwb-repository/dcr-public/3721109b-48a5-4ffb-a0ad-6d6a44f2f288/ff45dfca-1050-4265-93ef-4e7d702322e4/vdi.resources.Desktop.AdobeFlashSettings.html for details.