### PR TITLE
Updates to VMware.HCX to aide end to end automation and infrastructure testing

### DIFF
--- a/Modules/VMware.HCX/VMware.HCX.psd1
+++ b/Modules/VMware.HCX/VMware.HCX.psd1
@@ -36,7 +36,7 @@ Description = 'PowerShell Module for Managing Hybrid Cloud Extension (HCX) on VM
 PowerShellVersion = '6.0'
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Connect-HcxServer', 'Get-HcxCloudConfig', 'Get-HcxEndpoint', 'New-HcxMigration', 'Get-HcxMigration', 'Connect-HcxVAMI', 'Get-HcxVCConfig', 'Set-HcxLicense', 'Set-HcxVCConfig', 'Get-HcxNSXConfig', 'Set-HcxNSXConfig', 'Get-HcxCity', 'Get-HcxLocation', 'Set-HcxLocation', 'Get-HcxRoleMapping', 'Set-HcxRoleMapping', 'Get-HcxProxy', 'Set-HcxProxy', 'Remove-HcxProxy'
+FunctionsToExport = 'Connect-HcxServer', 'Get-HcxCloudConfig', 'Get-HcxEndpoint', 'New-HcxMigration', 'Get-HcxMigration', 'Connect-HcxVAMI', 'Get-HcxVCConfig', 'Set-HcxLicense', 'Set-HcxVCConfig', 'Get-HcxNSXConfig', 'Set-HcxNSXConfig', 'Get-HcxCity', 'Get-HcxLocation', 'Set-HcxLocation', 'Get-HcxRoleMapping', 'Set-HcxRoleMapping', 'Get-HcxProxy', 'Set-HcxProxy', 'Remove-HcxProxy', 'Get-HcxLicense'
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()
 

--- a/Modules/VMware.HCX/VMware.HCX.psm1
+++ b/Modules/VMware.HCX/VMware.HCX.psm1
@@ -570,22 +570,60 @@ Function Get-HcxVCConfig {
 #>
     If (-Not $global:hcxVAMIConnection) { Write-error "HCX Auth Token not found, please run Connect-HcxVAMI " } Else {
         $vcConfigUrl = $global:hcxVAMIConnection.Server + "/api/admin/global/config/vcenter"
+		$pscConfigUrl = $global:hcxVAMIConnection.Server + "/api/admin/global/config/lookupservice"
 
         if($PSVersionTable.PSEdition -eq "Core") {
             $vcRequests = Invoke-WebRequest -Uri $vcConfigUrl -Method GET -Headers $global:hcxVAMIConnection.headers -UseBasicParsing -SkipCertificateCheck
+            $ssoRequests = Invoke-WebRequest -Uri $pscConfigUrl -Method GET -Headers $global:hcxVAMIConnection.headers -UseBasicParsing -SkipCertificateCheck
         } else {
             $vcRequests = Invoke-WebRequest -Uri $vcConfigUrl -Method GET -Headers $global:hcxVAMIConnection.headers -UseBasicParsing
+            $ssoRequests = Invoke-WebRequest -Uri $pscConfigUrl -Method GET -Headers $global:hcxVAMIConnection.headers -UseBasicParsing
         }
         $vcData = ($vcRequests.content | ConvertFrom-Json).data.items
+		$ssoData = ($ssoRequests.content | ConvertFrom-Json).data.items
 
         $tmp = [pscustomobject] @{
             Name = $vcData.config.name;
+			UserName = $vcData.Config.userName
+			LookupServiceUrl = $ssoData.config.lookupServiceUrl
             Version = $vcData.config.version;
             Build = $vcData.config.buildNumber;
             UUID = $vcData.config.vcuuid;
             HCXUUID = $vcData.config.uuid;
         }
         $tmp
+    }
+}
+
+Function Get-HcxLicense {
+    <#
+        .NOTES
+        ===========================================================================
+        Created by:    Mark McGilly
+        Date:          4/29/2019
+        Organization:  Liberty Mutual Insurance
+        ===========================================================================
+
+        .SYNOPSIS
+            Returns the license key that is registered with HCX Manager
+        .DESCRIPTION
+            This cmdlet returns the license key registered with HCX Manager
+        .EXAMPLE
+            Get-HcxLicense
+    #>
+
+        If (-Not $global:hcxVAMIConnection) { Write-error "HCX Auth Token not found, please run Connect-HcxVAMI " } Else {
+        $hcxConfigUrl = $global:hcxVAMIConnection.Server + "/api/admin/global/config/hcx"
+
+        if($PSVersionTable.PSEdition -eq "Core") {
+            $licenseRequests = Invoke-WebRequest -Uri $hcxConfigUrl -Method GET -Headers $global:hcxVAMIConnection.headers -UseBasicParsing -SkipCertificateCheck
+        } else {
+            $licenseRequests = Invoke-WebRequest -Uri $hcxConfigUrl -Method GET -Headers $global:hcxVAMIConnection.headers -UseBasicParsing
+        }
+        $license = ($licenseRequests.content | ConvertFrom-Json).data.items
+        if($licenseRequests) {
+            $license.config.activationKey
+        }
     }
 }
 
@@ -800,6 +838,7 @@ Function Get-HcxNSXConfig {
 
         $tmp = [pscustomobject] @{
             Name = $nsxData.config.url;
+			UserName = $nsxData.config.userName
             Version = $nsxData.config.version;
             HCXUUID = $nsxData.config.uuid;
         }
@@ -1211,6 +1250,7 @@ Function Set-HcxProxy {
         [Parameter(Mandatory=$True)]$ProxyPort,
         [Parameter(Mandatory=$False)]$ProxyUser,
         [Parameter(Mandatory=$False)]$ProxyPassword,
+		[Parameter(Mandatory=$False)]$ProxyExclusions,
         [Switch]$Troubleshoot
     )
 
@@ -1225,7 +1265,7 @@ Function Set-HcxProxy {
             config = @{
                 proxyHost = "$ProxyServer";
                 proxyPort = "$ProxyPort";
-                nonProxyHosts = "";
+                nonProxyHosts = "$ProxyExclusions";
                 userName = "$ProxyUser";
                 password = "$ProxyPassword";
             }

--- a/Modules/VMware.HCX/VMware.HCX.psm1
+++ b/Modules/VMware.HCX/VMware.HCX.psm1
@@ -570,7 +570,7 @@ Function Get-HcxVCConfig {
 #>
     If (-Not $global:hcxVAMIConnection) { Write-error "HCX Auth Token not found, please run Connect-HcxVAMI " } Else {
         $vcConfigUrl = $global:hcxVAMIConnection.Server + "/api/admin/global/config/vcenter"
-		$pscConfigUrl = $global:hcxVAMIConnection.Server + "/api/admin/global/config/lookupservice"
+        $pscConfigUrl = $global:hcxVAMIConnection.Server + "/api/admin/global/config/lookupservice"
 
         if($PSVersionTable.PSEdition -eq "Core") {
             $vcRequests = Invoke-WebRequest -Uri $vcConfigUrl -Method GET -Headers $global:hcxVAMIConnection.headers -UseBasicParsing -SkipCertificateCheck
@@ -580,12 +580,12 @@ Function Get-HcxVCConfig {
             $ssoRequests = Invoke-WebRequest -Uri $pscConfigUrl -Method GET -Headers $global:hcxVAMIConnection.headers -UseBasicParsing
         }
         $vcData = ($vcRequests.content | ConvertFrom-Json).data.items
-		$ssoData = ($ssoRequests.content | ConvertFrom-Json).data.items
+        $ssoData = ($ssoRequests.content | ConvertFrom-Json).data.items
 
         $tmp = [pscustomobject] @{
             Name = $vcData.config.name;
-			UserName = $vcData.Config.userName
-			LookupServiceUrl = $ssoData.config.lookupServiceUrl
+            UserName = $vcData.Config.userName
+            LookupServiceUrl = $ssoData.config.lookupServiceUrl
             Version = $vcData.config.version;
             Build = $vcData.config.buildNumber;
             UUID = $vcData.config.vcuuid;
@@ -838,7 +838,7 @@ Function Get-HcxNSXConfig {
 
         $tmp = [pscustomobject] @{
             Name = $nsxData.config.url;
-			UserName = $nsxData.config.userName
+            UserName = $nsxData.config.userName
             Version = $nsxData.config.version;
             HCXUUID = $nsxData.config.uuid;
         }
@@ -1250,7 +1250,7 @@ Function Set-HcxProxy {
         [Parameter(Mandatory=$True)]$ProxyPort,
         [Parameter(Mandatory=$False)]$ProxyUser,
         [Parameter(Mandatory=$False)]$ProxyPassword,
-		[Parameter(Mandatory=$False)]$ProxyExclusions,
+        [Parameter(Mandatory=$False)]$ProxyExclusions,
         [Switch]$Troubleshoot
     )
 


### PR DESCRIPTION
To increase coverage of infrastructure testing with Pester I added the ability to retrieve the License key as well as more detail about the vCenters and NSX Managers registered with HCX
Added Get-HcxLicense function
Added ability to return UserName from Get-HcxNSXConfig
Added ability to return UserName, LookupServiceURL from Get-HcxVCConfig

To help end to end automation allow Proxy Exclusions to be configured in Set-HcxProxy
Added parameter to set Proxy Exclusions in Set-HcxProxy