### PR TITLE
Update VMware.Hv.Helper

### DIFF
--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psd1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '1.1'
+ModuleVersion = '1.3'
 
 # ID used to uniquely identify this module
 GUID = '6d3f7fb5-4e52-43d8-91e1-f65f72532a1d'

--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -8384,10 +8384,10 @@ function Get-HVEntitlement {
       $userInfo = Get-UserInfo -UserName $User
       $UserOrGroupName = $userInfo.Name
       $Domain = $userInfo.Domain
-      $nameFilter = Get-HVQueryFilter 'base.name' -Eq $UserOrGroupName
+      $nameFilter = Get-HVQueryFilter 'base.loginName' -Eq $UserOrGroupName
       $AndFilter += $nameFilter
-      $doaminFilter = Get-HVQueryFilter 'base.domain' -Eq $Domain
-      $AndFilter += $doaminFilter
+      $domainFilter = Get-HVQueryFilter 'base.domain' -Eq $Domain
+      $AndFilter += $domainFilter
     }
     if ($type -eq 'group'){
     	$IsGroup = ($Type -eq 'Group')

--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -1,5 +1,5 @@
 #Script Module : VMware.Hv.Helper
-#Version       : 1.2
+#Version       : 1.3
 
 #Copyright © 2016 VMware, Inc. All Rights Reserved.
 
@@ -10618,7 +10618,7 @@ function Get-HVHealth {
 	  param(
 		
 		[Parameter(Mandatory = $false)]
-    [ValidateSet('ADDomain', 'CertificateSSOConnector', 'ConnectionServer', 'EventDatabase', 'SAMLAuthenticator', 'SecurityServer', 'ViewComposer', 'VirtualCenter', 'pod')]
+    [ValidateSet('ADDomain', 'CertificateSSOConnector', 'ConnectionServer', 'EventDatabase', 'SAMLAuthenticator', 'SecurityServer', 'ViewComposer', 'VirtualCenter', 'Pod')]
     [string]
     $Servicename = 'ConnectionServer',
 			

--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -12283,7 +12283,6 @@ Function New-HVManualApplication {
         return
     }
     Write-Host "Application creation of '$Name' has failed. $_"
-    Return $AppSpec
   }
   end {
     [System.GC]::Collect()


### PR DESCRIPTION
**New Features**

- `Set-HVApplication` function
Updates existing Application Pools
- Updated module version to 1.3

**Fixes**

- Fixed an issue with `New-HVManualApplication` and multi display parameters. The removed parameters do not exist in the API and therefore caused an error.
- Fixed an issue where `New-HVPreInstalledApplication` didn't check properly if an application already existed.

**Improvements**

- Added an additional EntityID Type to `Get-InternalName` to support `GlobalApplicationEntitlement`
- Processed the module through PSScriptAnalyzer to more closely align with best practices
- Added a warning to `Get-HvVcenterServerHealth` in preparation to deprecate it
- Added the `ApplicationID` parameter to `New-HVPreinstalledApplication` function. This allows the creation of duplicate applications and addresses Issue #303 
- Added `ShouldProcess` support to `Remove-HVApplication` since this is a High impact action
