### PR TITLE
Add DomainName param to New-NSXTSegment

### DIFF
--- a/Modules/VMware.VMC.NSXT/VMware.VMC.NSXT.psm1
+++ b/Modules/VMware.VMC.NSXT/VMware.VMC.NSXT.psm1
@@ -159,6 +159,7 @@ Function New-NSXTSegment {
         [Parameter(Mandatory=$True)]$Name,
         [Parameter(Mandatory=$True)]$Gateway,
         [Parameter(Mandatory=$False)]$DHCPRange,
+        [Parameter(Mandatory=$False)]$DomainName,
         [Switch]$DHCP,
         [Switch]$Troubleshoot
     )
@@ -179,6 +180,11 @@ Function New-NSXTSegment {
             display_name = $Name;
             subnets = @($subnets)
         }
+
+        if($DomainName) {
+            $payload.domain_name = $DomainName
+        }
+
         $body = $payload | ConvertTo-Json -depth 4
 
         $method = "PUT"

--- a/Modules/VMware.VMC.NSXT/VMware.VMC.NSXT.psm1
+++ b/Modules/VMware.VMC.NSXT/VMware.VMC.NSXT.psm1
@@ -153,6 +153,8 @@ Function New-NSXTSegment {
     .EXAMPLE
         New-NSXTSegment -Name "sddc-cgw-network-4" -Gateway "192.168.4.1/24" -DHCP -DHCPRange "192.168.4.2-192.168.4.254"
     .EXAMPLE
+        New-NSXTSegment -Name "sddc-cgw-network-4" -Gateway "192.168.4.1/24" -DHCP -DHCPRange "192.168.4.2-192.168.4.254" -DomainName 'vmc.local'
+    .EXAMPLE
         New-NSXTSegment -Name "sddc-cgw-network-5" -Gateway "192.168.5.1/24"
 #>
     Param (


### PR DESCRIPTION
Allows end user to specify the DNS domain name for the network segment.

Performed tests with & without parameter against my SDDC successfully.

Resolves #320 