### PR TITLE
Fixing the authorize request to use the recently updated API change. …

### DIFF
--- a/Modules/VMware.VMC.NSXT/VMware.VMC.NSXT.psm1
+++ b/Modules/VMware.VMC.NSXT/VMware.VMC.NSXT.psm1
@@ -37,7 +37,7 @@ Function Connect-NSXTProxy {
         }
     }
 
-    $results = Invoke-WebRequest -Uri "https://console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize?refresh_token=$RefreshToken" -Method POST -ContentType "application/json" -UseBasicParsing -Headers @{"csp-auth-token"="$RefreshToken"}
+    $results = Invoke-WebRequest -Uri "https://console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize" -Method POST -Headers @{accept='application/json'} -Body "refresh_token=$RefreshToken"
     if($results.StatusCode -ne 200) {
         Write-Host -ForegroundColor Red "Failed to retrieve Access Token, please ensure your VMC Refresh Token is valid and try again"
         break


### PR DESCRIPTION
…Refresh tokens via the query param were deprecated. This breaks some of the connect commands.

https://console.cloud.vmware.com/csp/gateway/am/api/swagger-ui.html#/Authentication/getAccessTokenByApiRefreshTokenUsingPOST