### PR TITLE
On the off chance someone does not have PowerCLI installed

### DIFF
--- a/Scripts/At_Your_Fingertips/NewProfile.ps1
+++ b/Scripts/At_Your_Fingertips/NewProfile.ps1
@@ -89,7 +89,7 @@ function Set-Title
     $pcliModule = Get-Module -Name VMware.PowerCLI -ListAvailable |
     Sort-Object -Property Version -Descending |
     Select-Object -First 1
-    $pcli = " - PCLI: $($pcliModule.Version.ToString())"
+	$pcli = " - PCLI: $(if($pcliModule){$pcliModule.Version.ToString()}else{'na'})"
 
     # If git is present and if in a git controlled folder, display repositoryname/current_branch
     $gitStr = ''


### PR DESCRIPTION
Handle ToString() error when PCLI is not present

Signed-off-by: Luc Dekens <dekens.luc@gmail.com>