### PR TITLE
Use first section match for New-NSXTDistFirewall

### DIFF
--- a/Modules/VMware.VMC.NSXT/VMware.VMC.NSXT.psm1
+++ b/Modules/VMware.VMC.NSXT/VMware.VMC.NSXT.psm1
@@ -1473,7 +1473,7 @@ Function New-NSXTDistFirewall {
 
     If (-Not $global:nsxtProxyConnection) { Write-error "No NSX-T Proxy Connection found, please use Connect-NSXTProxy" } Else {
 
-        $sectionId = (Get-NSXTDistFirewallSection -Name $Section).Id
+        $sectionId = (Get-NSXTDistFirewallSection -Name $Section)[0].Id
 
         $destinationGroups = @()
         foreach ($group in $DestinationGroup) {


### PR DESCRIPTION
Creates the distributed firewall rule in the first section matched by name.

Performed positive & negative tests against my SDDC successfully.

Resolves #328