### PR TITLE
Updating to latest CSP Auth API

### DIFF
--- a/Modules/VMware.CSP/VMware.CSP.psm1
+++ b/Modules/VMware.CSP/VMware.CSP.psm1
@@ -21,8 +21,7 @@
         [Parameter(Mandatory=$true)][String]$RefreshToken
     )
 
-    $body = "refresh_token=$RefreshToken"
-    $results = Invoke-WebRequest -Uri "https://console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize" -Method POST -ContentType "application/x-www-form-urlencoded" -UseBasicParsing -Body $body
+    $results = Invoke-WebRequest -Uri "https://console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize" -Method POST -Headers @{accept='application/json'} -Body "refresh_token=$RefreshToken"
     if($results.StatusCode -ne 200) {
         Write-Host -ForegroundColor Red "Failed to retrieve Access Token, please ensure your VMC Refresh Token is valid and try again"
         break

--- a/Modules/VMware.DRaaS/VMware.DRaaS.psm1
+++ b/Modules/VMware.DRaaS/VMware.DRaaS.psm1
@@ -32,7 +32,7 @@ Function Connect-DRaas {
 
     }
 
-    $results = Invoke-WebRequest -Uri "https://console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize?refresh_token=$RefreshToken" -Method POST -ContentType "application/json" -UseBasicParsing -Headers @{"csp-auth-token"="$RefreshToken"}
+    $results = Invoke-WebRequest -Uri "https://console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize" -Method POST -Headers @{accept='application/json'} -Body "refresh_token=$RefreshToken"
     if($results.StatusCode -ne 200) {
         Write-Host -ForegroundColor Red "Failed to retrieve Access Token, please ensure your VMC Refresh Token is valid and try again"
         break

--- a/Modules/VMware.HCX/VMware.HCX.psm1
+++ b/Modules/VMware.HCX/VMware.HCX.psm1
@@ -1382,7 +1382,7 @@ Function Connect-HcxCloudServer {
         [Switch]$Troubleshoot
     )
 
-    $results = Invoke-WebRequest -Uri "https://console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize?refresh_token=$RefreshToken" -Method POST -ContentType "application/json" -UseBasicParsing -Headers @{"csp-auth-token"="$RefreshToken"}
+    $results = Invoke-WebRequest -Uri "https://console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize" -Method POST -Headers @{accept='application/json'} -Body "refresh_token=$RefreshToken"
     if($results.StatusCode -ne 200) {
         Write-Host -ForegroundColor Red "Failed to retrieve Access Token, please ensure your VMC Refresh Token is valid and try again"
         break


### PR DESCRIPTION
CSP has deprecated and removed authorize method of including Refresh Token in query param, updating to latest support method in various VMC modules which make use of CSP login API