### PR TITLE
Fixes for VMware.Hv.Helper

### DIFF
--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psd1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '1.3'
+ModuleVersion = '1.3.1'
 
 # ID used to uniquely identify this module
 GUID = '6d3f7fb5-4e52-43d8-91e1-f65f72532a1d'

--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -7767,7 +7767,7 @@ function Get-HVPoolSpec {
   if (! $DesktopInfoPsObj.GlobalEntitlementData.GlobalEntitlement) {
     $DesktopPsObj.GlobalEntitlementData = $null
   } else {
-    $entityId.Id = $DesktopInfoPsObj.GlobalEntitlementData.GlobalEntitlement.Id
+    $entityId = $DesktopInfoPsObj.GlobalEntitlementData.GlobalEntitlement
     $DesktopPsObj.GlobalEntitlementData = Get-HVInternalName -EntityId $entityId
   }
 
@@ -8025,7 +8025,13 @@ function Get-HVInternalName {
        }
        'GlobalApplicationEntitlement' {
          $info = $services.GlobalApplicationEntitlement.GlobalApplicationEntitlement_Get($EntityId)
-         return $info.Base.displayName
+         return $info.base.displayName
+       }
+       'GlobalEntitlement' {
+        $GlobalEntitlementID = New-Object VMware.Hv.GlobalEntitlementId
+        $GlobalEntitlementID.Id = $EntityID.Id
+        $info = $services.GlobalEntitlement.GlobalEntitlement_Get($GlobalEntitlementID)
+        return $info.base.displayname
        }
        default {
          $base64String  = $tokens[$tokens.Length-1]

--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -3746,6 +3746,7 @@ function New-HVPool {
     #desktopSpec.desktopSettings.logoffSettings.allowUsersToResetMachines
     [Parameter(Mandatory = $false,ParameterSetName = 'INSTANT_CLONE')]
     [Parameter(Mandatory = $false,ParameterSetName = "LINKED_CLONE")]
+    [Parameter(Mandatory = $false,ParameterSetName = 'MANUAL')]
     [boolean]$allowUsersToResetMachines = $false,
 
     #desktopSpec.desktopSettings.logoffSettings.allowMultipleSessionsPerUser
@@ -3777,23 +3778,27 @@ function New-HVPool {
     #desktopSpec.desktopSettings.logoffSettings.supportedDisplayProtocols
     [Parameter(Mandatory = $false,ParameterSetName = 'INSTANT_CLONE')]
     [Parameter(Mandatory = $false,ParameterSetName = "LINKED_CLONE")]
+    [Parameter(Mandatory = $false,ParameterSetName = 'MANUAL')]
     [ValidateSet('RDP', 'PCOIP', 'BLAST')]
     [string[]]$supportedDisplayProtocols = @('RDP', 'PCOIP', 'BLAST'),
 
     #desktopSpec.desktopSettings.logoffSettings.defaultDisplayProtocol
     [Parameter(Mandatory = $false,ParameterSetName = 'INSTANT_CLONE')]
-    [Parameter(Mandatory = $false,ParameterSetName = "LINKED_CLONE")]
+    [Parameter(Mandatory = $false,ParameterSetName = 'LINKED_CLONE')]
+    [Parameter(Mandatory = $false,ParameterSetName = 'MANUAL')]
     [ValidateSet('RDP', 'PCOIP', 'BLAST')]
     [string]$defaultDisplayProtocol = 'PCOIP',
 
     #desktopSpec.desktopSettings.logoffSettings.allowUsersToChooseProtocol
     [Parameter(Mandatory = $false,ParameterSetName = 'INSTANT_CLONE')]
     [Parameter(Mandatory = $false,ParameterSetName = "LINKED_CLONE")]
+    [Parameter(Mandatory = $false,ParameterSetName = 'MANUAL')]
     [int]$allowUsersToChooseProtocol = $true,
 
     #desktopSpec.desktopSettings.logoffSettings.enableHTMLAccess
     [Parameter(Mandatory = $false,ParameterSetName = 'INSTANT_CLONE')]
     [Parameter(Mandatory = $false,ParameterSetName = "LINKED_CLONE")]
+    [Parameter(Mandatory = $false,ParameterSetName = 'MANUAL')]
     [boolean]$enableHTMLAccess = $false,
 
     # DesktopPCoIPDisplaySettings

--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -1,5 +1,5 @@
 #Script Module : VMware.Hv.Helper
-#Version       : 1.3
+#Version       : 1.3.1
 
 #Copyright © 2016 VMware, Inc. All Rights Reserved.
 


### PR DESCRIPTION
Some small tweaks to VMware.Hv.Helper.

- Some of the parameters for New-HVPool are not properly included in the 'MANUAL' Parameter Set, thus causing issues when creating a Manual Pool. This fix addresses some of those

- EntityID was not properly being translated for Get-HVPoolSpec, causing downstream issues