### PR TITLE
New Function Set-VMHostSecureNTP

### DIFF
--- a/Scripts/Set-VMHostSecureNTP.ps1
+++ b/Scripts/Set-VMHostSecureNTP.ps1
@@ -77,8 +77,8 @@ function Set-VMHostSecureNTP {
             ## Remove all existing NTP Servers
             "Remove all existing NTP Servers ..."
             try {
-                foreach ($OldNtpServer in ($MyHost | Get-VMHostNtpServer)) {
-                    $MyHost | Remove-VMHostNtpServer -NtpServer $OldNtpServer -Confirm:$false
+                $MyHost | Get-VMHostNtpServer | Foreach-Object {
+                    Remove-VMHostNtpServer -VMHost $MyHost -NtpServer $_ -Confirm:$false
                 }
             }
             catch [System.Exception] {

--- a/Scripts/Set-VMHostSecureNTP.ps1
+++ b/Scripts/Set-VMHostSecureNTP.ps1
@@ -19,7 +19,7 @@ function Set-VMHostSecureNTP {
     ===========================================================================
 
     .DESCRIPTION
-    This function sets new NTP Servers on given ESXi Hosts and configures the host firewall to only accept NTP connections from this servers.
+    This function sets new NTP Servers on given ESXi Hosts and configures the host firewall to only accept NTP connections from these servers.
 
     .Example
     Get-VMHost | Set-VMHostSecureNTP -Secure
@@ -74,8 +74,8 @@ function Set-VMHostSecureNTP {
             if($NTPService.Policy -ne "on"){
                 Set-VMHostService -HostService $NTPService -Policy "on" -confirm:$False | Out-Null
             }
-            ## Remove all existiing NTP Servers
-            "Remove all existiing NTP Servers ..."
+            ## Remove all existing NTP Servers
+            "Remove all existing NTP Servers ..."
             try {
                 foreach ($OldNtpServer in ($MyHost | Get-VMHostNtpServer)) {
                     $MyHost | Remove-VMHostNtpServer -NtpServer $OldNtpServer -Confirm:$false

--- a/Scripts/Set-VMHostSecureNTP.ps1
+++ b/Scripts/Set-VMHostSecureNTP.ps1
@@ -45,7 +45,7 @@ function Set-VMHostSecureNTP {
 
     [CmdletBinding()]
     param( 
-        [Parameter(Mandatory=$True, ValueFromPipeline=$True, HelpMessage = "Specifies the hosts to configure.")]
+        [Parameter(Mandatory=$True, ValueFromPipeline=$True, Position=0, HelpMessage = "Specifies the hosts to configure.")]
             [ValidateNotNullorEmpty()]
             [VMware.VimAutomation.Types.VMHost[]] $VMHost,
         [Parameter(Mandatory=$False, ValueFromPipeline=$False, ParameterSetName="SetSecure", HelpMessage = "Execute Set and Secure operation for new NTP Servers")]

--- a/Scripts/Set-VMHostSecureNTP.ps1
+++ b/Scripts/Set-VMHostSecureNTP.ps1
@@ -15,17 +15,21 @@ function Set-VMHostSecureNTP {
     begin {
 
         function SetSecure ($MyHost) {
-            ## Get NTP Service  
+            ## Get NTP Service 
+            "Get NTP Service from VMHost ..." 
             $NTPService = $MyHost | Get-VMHostService | Where-Object {$_.key -eq "ntpd"}  
-            ## Stop NTP Service if running           
+            ## Stop NTP Service if running   
+            "Stop NTP Service if running  ..."        
             if($NTPService.Running -eq $True){
                 Stop-VMHostService -HostService $NTPService -Confirm:$false | Out-Null
             }
             ## Enable NTP Service
+            "Enable NTP Service if disabled..."
             if($NTPService.Policy -ne "on"){
                 Set-VMHostService -HostService $NTPService -Policy "on" -confirm:$False | Out-Null
             }
             ## Remove all existiing NTP Servers
+            "Remove all existiing NTP Servers ..."
             try {
                 foreach ($OldNtpServer in ($MyHost | Get-VMHostNtpServer)) {
                     $MyHost | Remove-VMHostNtpServer -NtpServer $OldNtpServer -Confirm:$false
@@ -35,36 +39,90 @@ function Set-VMHostSecureNTP {
                 Write-Warning "Error during removing existing NTP Servers on Host '$($MyHost.Name)'."
             }
             ## Set New NTP Servers
+            "Set New NTP Servers ..."
             foreach ($myNTP in $NTP) {
                 $MyHost | Add-VMHostNtpServer -ntpserver $myNTP -confirm:$False | Out-Null
             }
             ## Set Current time on Host
+            "Set Current time on VMHost ..."
             $HostTimeSystem = Get-View $MyHost.ExtensionData.ConfigManager.DateTimeSystem
             $HostTimeSystem.UpdateDateTime([DateTime]::UtcNow)
             ## Start NTP Service
+            "Start NTP Service ..."
             Start-VMHostService -HostService $NTPService -confirm:$False | Out-Null
-            ## Get NTP CLient Forewall Rule
+            ## Get ESXCLI -V2
             $esxcli = Get-ESXCLI -VMHost $MyHost -v2
-            $esxcliargs = $esxcli.network.firewall.ruleset.rule.list.CreateArgs()
-            $esxcliargs.rulesetid = "ntpClient"
+            ## Get NTP Client Firewall
+            "Get NTP Client Firewall ..."
             try {
-                $esxcli.network.firewall.ruleset.rule.list.Invoke($esxcliargs)
+                $FirewallGet = $esxcli.network.firewall.get.Invoke()
                 }
                 catch [System.Exception]  {
                     Write-Warning "Error during Rule List. See latest errors..."
                 }
-            ## Set NTP Client Firewall Rule
-            $esxcliargs = $esxcli.network.firewall.ruleset.set.CreateArgs()
-            $esxcliargs.enabled = "true"
-            $esxcliargs.allowedall = "false"
+            "`tLoded: $($FirewallGet.Loaded)"
+            "`tEnabled: $($FirewallGet.Enabled)"
+            "`tDefaultAction: $($FirewallGet.DefaultAction)"
+            ## Get NTP Client Firewall Rule
+            "Get NTP Client Firewall RuleSet ..."
+            $esxcliargs = $esxcli.network.firewall.ruleset.list.CreateArgs()
             $esxcliargs.rulesetid = "ntpClient"
             try {
-                $esxcli.network.firewall.ruleset.set.Invoke($esxcliargs)
+                $FirewallRuleList = $esxcli.network.firewall.ruleset.list.Invoke($esxcliargs)
                 }
                 catch [System.Exception]  {
-                    Write-Warning "Error during Rule Set. See latest errors..."
+                    Write-Warning "Error during Rule List. See latest errors..."
                 }
+            "`tEnabled: $($FirewallRuleList.Enabled)"
+            "Get NTP Client Firewall Rule AllowedIP ..."
+            $esxcliargs = $esxcli.network.firewall.ruleset.allowedip.list.CreateArgs()
+            $esxcliargs.rulesetid = "ntpClient"
+            try {
+                $FirewallRuleAllowedIPList = $esxcli.network.firewall.ruleset.allowedip.list.Invoke($esxcliargs)
+                }
+                catch [System.Exception]  {
+                    Write-Warning "Error during Rule List. See latest errors..."
+                }
+            "`tAllowed IP Addresses: $($FirewallRuleAllowedIPList.AllowedIPAddresses)"
+            ## Remove Existing IP from firewall rule
+            ## BUG: If AllowedIP was enabled and is disabled now, old IPs will not be removed
+            "Remove Existing IP from firewall rule ..."
+            if ($FirewallRuleAllowedIPList.AllowedIPAddresses -ne "All") {
+                foreach ($IP in $FirewallRuleAllowedIPList.AllowedIPAddresses) {
+                    $esxcliargs = $esxcli.network.firewall.ruleset.allowedip.remove.CreateArgs()
+                    $esxcliargs.rulesetid = "ntpClient"
+                    $esxcliargs.ipaddress = $IP
+                    try {
+                        $esxcli.network.firewall.ruleset.allowedip.remove.Invoke($esxcliargs)
+                        }
+                        catch [System.Exception]  {
+                            Write-Warning "Error during AllowedIP remove. See latest errors..."
+                        }
+                    
+                }
+                
+            }
+            ## Set NTP Client Firewall Rule
+            "Set NTP Client Firewall Rule ..."
+            if ($FirewallRuleList.Enabled -ne $True -or $FirewallRuleAllowedIPList.AllowedIPAddresses -eq "All") {
+                $esxcliargs = $esxcli.network.firewall.ruleset.set.CreateArgs()
+                if ($FirewallRuleList.Enabled -ne $True) {
+                    $esxcliargs.enabled = "true" 
+                }
+                if ($FirewallRuleAllowedIPList.AllowedIPAddresses -eq "All") {
+                    $esxcliargs.allowedall = "false"
+                }
+                $esxcliargs.rulesetid = "ntpClient"
+                try {
+                    $esxcli.network.firewall.ruleset.set.Invoke($esxcliargs)
+                    }
+                    catch [System.Exception]  {
+                        Write-Warning "Error during Rule Set. See latest errors..."
+                    }
+            }
             ## Set NTP Client Firewall Rule AllowedIP
+            ## BUG: If AllowedIP was enabled and is disabled now, a duplicate Ip Cannot be added
+            "Set NTP Client Firewall Rule AllowedIP ..."
             foreach ($myNTP in $NTP) {
                 $esxcliargs = $esxcli.network.firewall.ruleset.allowedip.add.CreateArgs()
                 $esxcliargs.ipaddress = $myNTP
@@ -73,7 +131,7 @@ function Set-VMHostSecureNTP {
                     $esxcli.network.firewall.ruleset.allowedip.add.Invoke($esxcliargs)
                 }
                 catch [System.Exception]  {
-                    Write-Warning "Error during Rule Update. See latest errors..."
+                    Write-Warning "Error during Rule AllowedIP Update. See latest errors..."
                 }             
             }
         }

--- a/Scripts/Set-VMHostSecureNTP.ps1
+++ b/Scripts/Set-VMHostSecureNTP.ps1
@@ -114,10 +114,10 @@ function Set-VMHostSecureNTP {
             "Get NTP Client Firewall ..."
             try {
                 $FirewallGet = $esxcli.network.firewall.get.Invoke()
-                }
-                catch [System.Exception]  {
-                    Write-Warning "Error during Rule List. See latest errors..."
-                }
+            }
+            catch [System.Exception]  {
+                Write-Warning "Error during Rule List. See latest errors..."
+            }
             "`tLoded: $($FirewallGet.Loaded)"
             "`tEnabled: $($FirewallGet.Enabled)"
             "`tDefaultAction: $($FirewallGet.DefaultAction)"
@@ -127,10 +127,10 @@ function Set-VMHostSecureNTP {
             $esxcliargs.rulesetid = "ntpClient"
             try {
                 $FirewallRuleList = $esxcli.network.firewall.ruleset.list.Invoke($esxcliargs)
-                }
-                catch [System.Exception]  {
-                    Write-Warning "Error during Rule List. See latest errors..."
-                }
+            }
+            catch [System.Exception]  {
+                Write-Warning "Error during Rule List. See latest errors..."
+            }
             "`tEnabled: $($FirewallRuleList.Enabled)"
             ## Set NTP Client Firewall Rule
             "Set NTP Client Firewall Rule ..."
@@ -140,24 +140,24 @@ function Set-VMHostSecureNTP {
             $esxcliargs.rulesetid = "ntpClient"
             try {
                 $esxcli.network.firewall.ruleset.set.Invoke($esxcliargs)
-                }
-                catch [System.Exception]  {
-                    $ErrorMessage = $_.Exception.Message
-                    if ($ErrorMessage -ne "Already use allowed ip list") {
-                        Write-Warning "Error during Rule Set. See latest errors..."
-
-                    }
+            }
+            catch [System.Exception]  {
+                $ErrorMessage = $_.Exception.Message
+                if ($ErrorMessage -ne "Already use allowed ip list") {
+                    Write-Warning "Error during Rule Set. See latest errors..."
 
                 }
+
+            }
             "Get NTP Client Firewall Rule AllowedIP ..."
             $esxcliargs = $esxcli.network.firewall.ruleset.allowedip.list.CreateArgs()
             $esxcliargs.rulesetid = "ntpClient"
             try {
                 $FirewallRuleAllowedIPList = $esxcli.network.firewall.ruleset.allowedip.list.Invoke($esxcliargs)
-                }
-                catch [System.Exception]  {
-                    Write-Warning "Error during Rule List. See latest errors..."
-                }
+            }
+            catch [System.Exception]  {
+                Write-Warning "Error during Rule List. See latest errors..."
+            }
             "`tAllowed IP Addresses: $($FirewallRuleAllowedIPList.AllowedIPAddresses -join ", ")"    
             ## Remove Existing IP from firewall rule
             "Remove Existing IP from firewall rule ..."
@@ -168,10 +168,10 @@ function Set-VMHostSecureNTP {
                     $esxcliargs.ipaddress = $IP
                     try {
                         $esxcli.network.firewall.ruleset.allowedip.remove.Invoke($esxcliargs)
-                        }
-                        catch [System.Exception]  {
-                            Write-Warning "Error during AllowedIP remove. See latest errors..."
-                        }
+                    }
+                    catch [System.Exception]  {
+                        Write-Warning "Error during AllowedIP remove. See latest errors..."
+                    }
                 }
                 
             }
@@ -197,10 +197,10 @@ function Set-VMHostSecureNTP {
             $esxcliargs.rulesetid = "ntpClient"
             try {
                 $FirewallRuleAllowedIPList = $esxcli.network.firewall.ruleset.allowedip.list.Invoke($esxcliargs)
-                }
-                catch [System.Exception]  {
-                    Write-Warning "Error during Rule List. See latest errors..."
-                }
+            }
+            catch [System.Exception]  {
+                Write-Warning "Error during Rule List. See latest errors..."
+            }
             "`tNew Allowed IP Addresses: $($FirewallRuleAllowedIPList.AllowedIPAddresses -join ", ")"    
             
             

--- a/Scripts/Set-VMHostSecureNTP.ps1
+++ b/Scripts/Set-VMHostSecureNTP.ps1
@@ -197,7 +197,7 @@ function Set-VMHostSecureNTP {
 
         }
 
-        function Secure ($myhost) {
+        function Secure ($MyHost) {
             ## Get NTP Servers
             "Get NTP Servers ..."
             [Array]$CurrentNTPServers = $MyHost | Get-VMHostNtpServer

--- a/Scripts/Set-VMHostSecureNTP.ps1
+++ b/Scripts/Set-VMHostSecureNTP.ps1
@@ -1,4 +1,48 @@
 function Set-VMHostSecureNTP {
+<#	
+    .NOTES
+    ===========================================================================
+    Created by: Markus Kraus
+    ===========================================================================
+    Changelog:  
+    2020.05 ver 1.0 Base Release  
+    ===========================================================================
+    External Code Sources: 
+    -
+    ===========================================================================
+    Tested Against Environment:
+    vSphere Version: vSphere 6.7 U3
+    PowerCLI Version: PowerCLI 11.5
+    PowerShell Version: 5.1
+    OS Version: Windows 10
+    Keyword: ESXi, NTP, Hardening, Security, Firewall 
+    ===========================================================================
+
+    .DESCRIPTION
+    This function sets new NTP Servers on given ESXi Hosts and configures the host firewall to only accept NTP connections from this servers.
+
+    .Example
+    Get-VMHost | Set-VMHostSecureNTP -Secure
+
+    .Example
+    Get-VMHost | Set-VMHostSecureNTP -Type SetSecure -NTP 10.100.1.1, 192.168.2.1
+
+    .PARAMETER VMHost
+    Specifies the hosts to configure
+
+    .PARAMETER SetSecure
+    Execute Set and Secure operation for new NTP Servers
+
+    .PARAMETER NTP
+    Specifies a Array of NTP Servers
+
+    .PARAMETER Secure
+    Execute Secure operation for exitsting NTP Servers
+
+#Requires PS -Version 5.1
+#Requires -Modules VMware.VimAutomation.Core, @{ModuleName="VMware.VimAutomation.Core";ModuleVersion="11.5.0.0"}
+#>
+
     [CmdletBinding()]
     param( 
         [Parameter(Mandatory=$True, ValueFromPipeline=$True, HelpMessage = "Specifies the hosts to configure.")]
@@ -6,7 +50,7 @@ function Set-VMHostSecureNTP {
             [VMware.VimAutomation.Types.VMHost[]] $VMHost,
         [Parameter(Mandatory=$False, ValueFromPipeline=$False, ParameterSetName="SetSecure", HelpMessage = "Execute Set and Secure operation for new NTP Servers")]
             [Switch] $SetSecure,
-        [Parameter(Mandatory=$True, ValueFromPipeline=$False,  ParameterSetName="SetSecure", HelpMessage = "Array of NTP Serbers")]
+        [Parameter(Mandatory=$True, ValueFromPipeline=$False,  ParameterSetName="SetSecure", HelpMessage = "Specifies a Array of NTP Servers")]
             [ValidateNotNullorEmpty()] 
             [Array] $NTP,
         [Parameter(Mandatory=$False, ValueFromPipeline=$False, ParameterSetName="Secure", HelpMessage = "Execute Secure operation for exitsting NTP Servers")]
@@ -268,8 +312,5 @@ function Set-VMHostSecureNTP {
         }
         
     }
-    
-    end {
-        
-    }
+
 }

--- a/Scripts/Set-VMHostSecureNTP.ps1
+++ b/Scripts/Set-VMHostSecureNTP.ps1
@@ -1,0 +1,90 @@
+function Set-VMHostSecureNTP {
+    [CmdletBinding()]
+    param( 
+        [Parameter(Mandatory=$True, ValueFromPipeline=$True, Position=0, HelpMessage = "Specifies the hosts to configure.")]
+            [ValidateNotNullorEmpty()]
+            [VMware.VimAutomation.Types.VMHost[]] $VMHost,
+        [Parameter(Mandatory=$False, ValueFromPipeline=$False, Position=1, HelpMessage = "Type of confugration")]
+            [ValidateSet("SetSecure","Secure")]
+            [String] $Type = "SetSecure",
+        [Parameter(Mandatory=$True, ValueFromPipeline=$False, Position=2, HelpMessage = "Array of NTP Serbers")]
+            [ValidateNotNullorEmpty()] 
+            [Array] $NTP   
+    )
+    
+    begin {
+
+        function SetSecure ($MyHost) {
+            ## Get NTP Service  
+            $NTPService = $MyHost | Get-VMHostService | Where-Object {$_.key -eq "ntpd"}  
+            ## Stop NTP Service if running           
+            if($NTPService.Running -eq $True){
+                Stop-VMHostService -HostService $NTPService -Confirm:$false | Out-Null
+            }
+            ## Enable NTP Service
+            if($NTPService.Policy -ne "on"){
+                Set-VMHostService -HostService $NTPService -Policy "on" -confirm:$False | Out-Null
+            }
+            ## Remove all existiing NTP Servers
+            try {
+                foreach ($OldNtpServer in ($MyHost | Get-VMHostNtpServer)) {
+                    $MyHost | Remove-VMHostNtpServer -NtpServer $OldNtpServer -Confirm:$false
+                }
+            }
+            catch [System.Exception] {
+                Write-Warning "Error during removing existing NTP Servers on Host '$($MyHost.Name)'."
+            }
+            ## Set New NTP Servers
+            foreach ($myNTP in $NTP) {
+                $MyHost | Add-VMHostNtpServer -ntpserver $myNTP -confirm:$False | Out-Null
+            }
+            ## Set Current time on Host
+            $HostTimeSystem = Get-View $MyHost.ExtensionData.ConfigManager.DateTimeSystem
+            $HostTimeSystem.UpdateDateTime([DateTime]::UtcNow)
+            ## Start NTP Service
+            Start-VMHostService -HostService $NTPService -confirm:$False | Out-Null
+            ## Get NTP CLient Forewall Rule
+            $esxcli = Get-ESXCLI -VMHost $MyHost -v2
+            $esxcliargs = $esxcli.network.firewall.ruleset.rule.list.CreateArgs()
+            $esxcliargs.rulesetid = "ntpClient"
+            try {
+                $esxcli.network.firewall.ruleset.rule.list.Invoke($esxcliargs)
+                }
+                catch [System.Exception]  {
+                    Write-Warning "Error during Rule List. See latest errors..."
+                }
+            ## Set NTP Client Firewall Rule
+            $esxcliargs = $esxcli.network.firewall.ruleset.set.CreateArgs()
+            $esxcliargs.enabled = "true"
+            $esxcliargs.allowedall = "false"
+            $esxcliargs.rulesetid = "ntpClient"
+            try {
+                $esxcli.network.firewall.ruleset.set.Invoke($esxcliargs)
+                }
+                catch [System.Exception]  {
+                    Write-Warning "Error during Rule Set. See latest errors..."
+                }
+            ## Set NTP Client Firewall Rule AllowedIP
+            foreach ($myNTP in $NTP) {
+                $esxcliargs = $esxcli.network.firewall.ruleset.allowedip.add.CreateArgs()
+                $esxcliargs.ipaddress = $myNTP
+                $esxcliargs.rulesetid = "ntpClient"
+                try {
+                    $esxcli.network.firewall.ruleset.allowedip.add.Invoke($esxcliargs)
+                }
+                catch [System.Exception]  {
+                    Write-Warning "Error during Rule Update. See latest errors..."
+                }             
+            }
+        }
+        
+    }
+    
+    process {
+        
+    }
+    
+    end {
+        
+    }
+}

--- a/Scripts/Set-VMHostSecureNTP.ps1
+++ b/Scripts/Set-VMHostSecureNTP.ps1
@@ -52,7 +52,7 @@ function Set-VMHostSecureNTP {
             [Switch] $SetSecure,
         [Parameter(Mandatory=$True, ValueFromPipeline=$False,  ParameterSetName="SetSecure", HelpMessage = "Specifies a Array of NTP Servers")]
             [ValidateNotNullorEmpty()] 
-            [Array] $NTP,
+            [ipaddress[]] $NTP,
         [Parameter(Mandatory=$False, ValueFromPipeline=$False, ParameterSetName="Secure", HelpMessage = "Execute Secure operation for exitsting NTP Servers")]
             [Switch] $Secure
 

--- a/Scripts/Set-VMHostSecureNTP.ps1
+++ b/Scripts/Set-VMHostSecureNTP.ps1
@@ -82,6 +82,11 @@ function Set-VMHostSecureNTP {
     
     process {
         
+        if ($Type -eq "SetSecure") {
+            "Executing Set and Secure operation..."
+            $VMHost | Foreach-Object { Write-Output (SetSecure $_) }
+        }
+        
     }
     
     end {


### PR DESCRIPTION
This function sets new NTP Servers on given ESXi Hosts and configures the host firewall to only accept NTP connections from these servers.

```
Get-VMHost | Set-VMHostSecureNTP -SetSecure -NTP 10.100.1.1, 192.168.2.1     

Execute Set and Secure operation for new NTP Servers ...
Get NTP Service from VMHost ...
Stop NTP Service if running  ...    
Enable NTP Service if disabled...   
Remove all existing NTP Servers ...
Set New NTP Servers ...
Set Current time on VMHost ...
Start NTP Service ...
Get NTP Client Firewall ...
        Loded: true
        Enabled: true
        DefaultAction: DROP
Get NTP Client Firewall RuleSet ...
        Enabled: true
Set NTP Client Firewall Rule ...
Get NTP Client Firewall Rule AllowedIP ...
        Allowed IP Addresses: 10.100.1.1
Remove Existing IP from firewall rule ...
true
Set NTP Client Firewall Rule AllowedIP ...
true
true
Get New NTP Client Firewall Rule AllowedIP ...
        New Allowed IP Addresses: 10.100.1.1, 192.168.2.1
Get New NTP Servers ...
        New NTP Servers: 10.100.1.1, 192.168.2.1
```