### PR TITLE
Enable quick disconnect for Disconnect-SsoAdminServer

### DIFF
--- a/Modules/VMware.vSphere.SsoAdmin/VMware.vSphere.SsoAdmin.psm1
+++ b/Modules/VMware.vSphere.SsoAdmin/VMware.vSphere.SsoAdmin.psm1
@@ -183,25 +183,11 @@ function Disconnect-SsoAdminServer {
          switch (@($global:DefaultSsoAdminServers).count) {
             { $_ -eq 1 } { $server = ($global:DefaultSsoAdminServers).ToArray()[0] ; break }
             { $_ -gt 1 } { 
-               $PSCmdlet.ThrowTerminatingError(
-                  [System.Management.Automation.ErrorRecord]::new(
-                     ([System.ApplicationException]"Connected to more than 1 SSO server, please specify a SSO server via -Server parameter"),
-                     'Disconnect-SsoAdminServer.ConnectedToMoreThanOneSSO',
-                     [System.Management.Automation.ErrorCategory]::InvalidOperation,
-                     $global:DefaultSsoAdminServers
-                  )
-               )
+               Throw 'Connected to more than 1 SSO server, please specify a SSO server via -Server parameter'
                break 
             }
             Default { 
-               $PSCmdlet.ThrowTerminatingError(
-                  [System.Management.Automation.ErrorRecord]::new(
-                     ([System.ApplicationException]"Not connected to SSO server."),
-                     'Disconnect-SsoAdminServer.NotConnectedToSSO',
-                     [System.Management.Automation.ErrorCategory]::ConnectionError,
-                     $global:DefaultSsoAdminServers
-                  )
-               )
+               Throw 'Not connected to SSO server.'
              }
          } 
       }

--- a/Modules/VMware.vSphere.SsoAdmin/src/test/ConnectDisconnect.Tests.ps1
+++ b/Modules/VMware.vSphere.SsoAdmin/src/test/ConnectDisconnect.Tests.ps1
@@ -84,6 +84,62 @@ Describe "Connect-SsoAdminServer and Disconnect-SsoAdminServer Tests" {
          $expected.IsConnected | Should Be $false
       }
 
+      It 'Diconnect-SsoAdminServer disconnects the currently connected SSO in case there is 1 SSO server' {
+         # Arrange
+         $expected = Connect-SsoAdminServer `
+               -Server $VcAddress `
+               -User $User `
+               -Password $Password `
+               -SkipCertificateCheck
+
+         # Act
+         Disconnect-SsoAdminServer -server $expected
+
+         # Assert
+         $global:DefaultSsoAdminServers | Should Not Contain $expected
+         $expected.IsConnected | Should Be $false
+      }
+
+      It 'Diconnect-SsoAdminServer does not disconnect if connected to more than 1 SSO server' {
+         # Arrange
+         $expected += @(Connect-SsoAdminServer `
+               -Server $VcAddress `
+               -User $User `
+               -Password $Password `
+               -SkipCertificateCheck)
+         $expected += @(Connect-SsoAdminServer `
+               -Server $VcAddress `
+               -User $User `
+               -Password $Password `
+               -SkipCertificateCheck)
+
+         # Act
+         {Disconnect-SsoAdminServer} | should -Throw
+         # Assert
+         (Compare-Object $global:DefaultSsoAdminServers $expected -IncludeEqual).Count | Should Be 2
+         $expected.IsConnected | Should -Contain $true
+      }
+
+      It 'Diconnect-SsoAdminServer does disconnect via pipeline if connected to more than 1 SSO server' {
+         # Arrange
+         $expected += @(Connect-SsoAdminServer `
+               -Server $VcAddress `
+               -User $User `
+               -Password $Password `
+               -SkipCertificateCheck)
+         $expected += @(Connect-SsoAdminServer `
+               -Server $VcAddress `
+               -User $User `
+               -Password $Password `
+               -SkipCertificateCheck)
+
+         # Act
+         $expected | Disconnect-SsoAdminServer
+         # Assert
+         $global:DefaultSsoAdminServers.count | Should Be 0
+         $expected.IsConnected | Should -not -Contain $true
+      }
+
       It 'Disconnects disconnected object' {
          # Arrange
          $expected = Connect-SsoAdminServer `

--- a/Modules/VMware.vSphere.SsoAdmin/src/test/ConnectDisconnect.Tests.ps1
+++ b/Modules/VMware.vSphere.SsoAdmin/src/test/ConnectDisconnect.Tests.ps1
@@ -116,7 +116,7 @@ Describe "Connect-SsoAdminServer and Disconnect-SsoAdminServer Tests" {
          # Act
          
          # Assert
-         {Disconnect-SsoAdminServer} | should -Throw
+         {Disconnect-SsoAdminServer} | should -Throw 'Connected to more than 1 SSO server, please specify a SSO server via -Server parameter'
          (Compare-Object $global:DefaultSsoAdminServers $expected -IncludeEqual).Count | Should Be 2
          $expected.IsConnected | Should -Contain $true
       }

--- a/Modules/VMware.vSphere.SsoAdmin/src/test/ConnectDisconnect.Tests.ps1
+++ b/Modules/VMware.vSphere.SsoAdmin/src/test/ConnectDisconnect.Tests.ps1
@@ -114,8 +114,9 @@ Describe "Connect-SsoAdminServer and Disconnect-SsoAdminServer Tests" {
                -SkipCertificateCheck)
 
          # Act
-         {Disconnect-SsoAdminServer} | should -Throw
+         
          # Assert
+         {Disconnect-SsoAdminServer} | should -Throw
          (Compare-Object $global:DefaultSsoAdminServers $expected -IncludeEqual).Count | Should Be 2
          $expected.IsConnected | Should -Contain $true
       }


### PR DESCRIPTION
This change would enable for Disconnect-SsoAdminServer to behave similar to other  disconnect cmdlets.
When connected to one SSO server , Disconnect-SsoAdminServer would disconnect user immediately, without asking from which server one wishes to disconnect.
When connected to more than one SSO server, Disconnect-SsoAdminServer would throw ever that a Server parameter has to be used since it is not possible to choose for the user from which server one wants to disconnect.
When not connected to a SSO server, Disconnect-SsoAdminServer would throw an error stating that there are no active connections established.
Tests were added for this change inside ConnectDisconnect.Tests.ps1 tests.
