### PR TITLE
Removed duplicate calculation of HostClusterID

### DIFF
--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -4809,8 +4809,6 @@ function New-HVPool {
         try {
           $desktopVirtualCenterProvisioningData = Get-HVPoolProvisioningData -vc $virtualCenterID -vmObject $desktopVirtualCenterProvisioningData
           $hostClusterId = $desktopVirtualCenterProvisioningData.HostOrCluster
-          $hostOrCluster_helper = New-Object VMware.Hv.HostOrClusterService
-          $hostClusterIds = (($hostOrCluster_helper.HostOrCluster_GetHostOrClusterTree($services, $desktopVirtualCenterProvisioningData.datacenter)).treeContainer.children.info).Id
           $desktopVirtualCenterStorageSettings = Get-HVPoolStorageObject -hostClusterIds $hostClusterId -storageObject $desktopVirtualCenterStorageSettings
           $DesktopVirtualCenterNetworkingSettings = Get-HVPoolNetworkSetting -networkObject $DesktopVirtualCenterNetworkingSettings
           $desktopCustomizationSettings = Get-HVPoolCustomizationSetting -vc $virtualCenterID -customObject $desktopCustomizationSettings


### PR DESCRIPTION
$hostClusterIds isn't used.  `Get-HVPoolProvisioningData` calls `HostOrCluster_GetHostOrClusterTree` and returns an object which contains the host/cluster id.  However, then the next two then call `HostOrCluster_GetHostOrClusterTree` again and the result is never used.