### PR TITLE
Address the Set-HvFarm error when trying to pass the value of $False to the flag -Value

### DIFF
--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -6134,9 +6134,9 @@ function Set-HVFarm {
     }
 
     $updates = @()
-    if ($key -and $value) {
+    if ($PSBoundParameters.ContainsKey("key") -and $PSBoundParameters.ContainsKey("value")) {
       $updates += Get-MapEntry -key $key -value $value
-    } elseif ($key -or $value) {
+    } elseif ($PSBoundParameters.ContainsKey("key") -or $PSBoundParameters.ContainsKey("value")) {
       Write-Error "Both key:[$key] and value:[$value] need to be specified"
     }
     if ($spec) {


### PR DESCRIPTION
This PR is meant to address the issue of `Set-HvFarm` erroring out when passing the value of `$False` to the `-Value` flag like so:

```PowerShell
Set-HvFarm -FarmName $farmName -Key $keyName -Value $False
```

This fix is based on an earlier PR that has been merged: https://github.com/vmware/PowerCLI-Example-Scripts/pull/131