### PR TITLE
Reversing 9d9ebc504b8b31e651cf56cf3336c020735b0fa6

### DIFF
--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -7108,7 +7108,7 @@ function Start-HVPool {
             $spec.Settings = New-Object VMware.Hv.DesktopPushImageSettings
             $spec.Settings.LogoffSetting = $logoffSetting
             $spec.Settings.StopOnFirstError = $stopOnFirstError
-            if ($startTime) { $spec.startTime = $startTime }
+            if ($startTime) { $spec.Settings.startTime = $startTime }
             if (!$confirmFlag -OR  $pscmdlet.ShouldProcess($poolList.$item)) {
               $desktop_helper.Desktop_SchedulePushImage($services,$item,$spec)
             }


### PR DESCRIPTION
The change made in https://github.com/vmware/PowerCLI-Example-Scripts/commit/9d9ebc504b8b31e651cf56cf3336c020735b0fa6 breaks ImagePush operations for Instant Clone pools. See the [API documentation](https://vdc-download.vmware.com/vmwb-repository/dcr-public/14109593-7ba5-4fb6-a71d-1c1e2ef74cb7/7a3d3dc5-1dcc-4c4c-a92a-a1d706f74657/vdi.resources.Desktop.PushImageSettings.html) for reference. 

The schema for `DesktopPushImageSpec` is as follows:

* DesktopPushImageSpec
  * Settings
    * StartTime