### PR TITLE
Address Issue 496

### DIFF
--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -10278,7 +10278,7 @@ function Set-HVGlobalSettings {
   process {
 
     $updates = @()
-    if ($key -and $value) {
+    if ( $PSBoundParameters.ContainsKey('Key') -and $PSBoundParameters.ContainsKey('Value') ) {
       $updates += Get-MapEntry -key $key -value $value
     } elseif ($key -or $value) {
       Write-Error "Both key:[$key] and value:[$value] needs to be specified"


### PR DESCRIPTION
Addressing Issue 496 to resolve the unintentional false condition when `-Value` is set to `$false` on `Set-HVGlobalSettings`

Signed-off-by: Matt Frey <mfrey@vmware.com>