### PR TITLE
Update SaltStackConfig.psm1

### DIFF
--- a/Modules/SaltStackConfig/SaltStackConfig.psm1
+++ b/Modules/SaltStackConfig/SaltStackConfig.psm1
@@ -22,6 +22,13 @@ Function Connect-SscServer {
   .EXAMPLE
     PS C:\> Connect-SscServer -Server 'salt.example.com' -Username 'bwuchner' -Password 'MyPassword1!' -AuthSource 'LAB Directory'
     This will use the 'Lab Directory' LDAP authentication source.
+  .EXAMPLE
+    PS C:\> Connect-SscServer -Server 'salt.example.com'
+    This will prompt for credentials
+  .EXAMPLE
+    $creds = Get-Credential
+    PS C:\> Connect-SscServer -Server 'salt.example.com' -Credential $creds -AuthSource 'LAB Directory'
+    This will connect to the 'LAB Directory' LDAP authentication source using a specified credential.
 #>
   param(
     [Parameter(Mandatory=$true, Position=0)][string]$server,


### PR DESCRIPTION
Improve Connect-SscServer to accept credentials instead of just plaintext username/password values.

We will make the PlainText parameter set items mandatory, so if you use this parameter set both values need to be provided.
However, if you don't specify any credentials at all as arguments, we will default to the optional Credential parameter set.  When the credential parameter set is used but the credential value is null, we will prompt for credentials using Get-Credential.

Signed-off-by: Brian Wuchner <brian.wuchner@gmail.com>