### PR TITLE
Update VMware.HV.Helper.psm1

### DIFF
--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -874,6 +874,9 @@ function Get-HVEvent {
 .PARAMETER MessageFilter
    String that can applied in filtering on 'Message' column.
 
+.PARAMETER SqlTimeout
+   Data query command timeout in seconds, default is 30 seconds.
+
 .EXAMPLE
    $e = Get-HVEvent -hvDbServer $hvDbServer
    $e.Events
@@ -925,7 +928,10 @@ function Get-HVEvent {
     [string]$ModuleFilter = "",
 
     [Parameter(Mandatory = $false)]
-    [string]$MessageFilter = ""
+    [string]$MessageFilter = "",
+
+    [Parameter(Mandatory = $false)]
+    [int]$SqlTimeout = 30
   )
 
   begin {
@@ -1022,7 +1028,7 @@ function Get-HVEvent {
     $command.CommandText = $query
     $adapter.SelectCommand = $command
     $DataTable = New-Object System.Data.DataTable
-    $adapter.Fill($DataTable)
+    $adapter.Fill($DataTable) | Out-Null
 
     $toDate = $DataTable.Rows[0][0]
     $fromDate = $toDate.AddDays(- ($timeInDays))
@@ -1055,6 +1061,7 @@ function Get-HVEvent {
     $adapter.SelectCommand = $command
 
     $DataTable = New-Object System.Data.DataTable
+    $adapter.SelectCommand.CommandTimeout = $SqlTimeout
     $adapter.Fill($DataTable) | Out-Null
 
     Write-Host "Number of records found : " $DataTable.Rows.Count


### PR DESCRIPTION
Fixes #364 - Get-HVEvent timeout issue
Changes to line 877-879 adds help for a new SqlTimeout parameter added to Get-HVEvent
Changes to line 931-934 add support for the new SqlTimeout parameter with a default value of 30 seconds.
Changes to line 1064 implements the timeout parameter created above when executing the query.

The change to line 1031 resolves an unrelated issue where I was seeing an extra '1' in the output from Get-HVEvent.  Adding the `Out-Null` statement is similar to another example in this same function which already existed on line 1065.  Adding the `Out-Null` statement did resolve the extra '1' displayed in the output.

Signed-off-by: Brian Wuchner <brian.wuchner@gmail.com>