### PR TITLE
Update SaltStackConfig.psm1

### DIFF
--- a/Modules/SaltStackConfig/SaltStackConfig.psd1
+++ b/Modules/SaltStackConfig/SaltStackConfig.psd1
@@ -17,7 +17,7 @@ SPDX-License-Identifier: BSD-2-Clause
 RootModule = 'SaltStackConfig.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.5'
+ModuleVersion = '0.0.6'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Modules/SaltStackConfig/SaltStackConfig.psm1
+++ b/Modules/SaltStackConfig/SaltStackConfig.psm1
@@ -36,7 +36,8 @@ Function Connect-SscServer {
     [Parameter(Mandatory=$true, ParameterSetName='PlainText', Position=2)][ValidateNotNullOrEmpty()][string]$password,
     [Parameter(Mandatory=$false, Position=3)][string]$AuthSource='internal',
     [Parameter(Mandatory=$false, ParameterSetName='Credential')][PSCredential]$Credential,
-    [Parameter(Mandatory=$false)][Switch]$SkipCertificateCheck
+    [Parameter(Mandatory=$false)][Switch]$SkipCertificateCheck,
+    [Parameter(Mandatory=$false)][ValidateSet('Tls13','Tls12','Tls11','Tls','SystemDefault')]$SslProtocol
   )
 
   if ($PSCmdlet.ParameterSetName -eq 'Credential' -AND $Credential -eq $null) { $Credential = Get-Credential}
@@ -58,10 +59,13 @@ Function Connect-SscServer {
         }
     }
 "@
-    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12'
     [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
   } # end if SkipCertificate Check
   
+  if ($SslProtocol) {
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]$SslProtocol
+  }
+
   $loginBody = @{'username'=$username; 'password'=$password; 'config_name'=$AuthSource}
   try {
     $webRequest = Invoke-WebRequest -Uri "https://$server/account/login" -SessionVariable ws

--- a/Modules/SaltStackConfig/SaltStackConfig.psm1
+++ b/Modules/SaltStackConfig/SaltStackConfig.psm1
@@ -35,7 +35,8 @@ Function Connect-SscServer {
     [Parameter(Mandatory=$true, ParameterSetName='PlainText', Position=1)][string]$username,
     [Parameter(Mandatory=$true, ParameterSetName='PlainText', Position=2)][ValidateNotNullOrEmpty()][string]$password,
     [Parameter(Mandatory=$false, Position=3)][string]$AuthSource='internal',
-    [Parameter(Mandatory=$false, ParameterSetName='Credential')][PSCredential]$Credential
+    [Parameter(Mandatory=$false, ParameterSetName='Credential')][PSCredential]$Credential,
+    [Parameter(Mandatory=$false)][Switch]$SkipCertificateCheck
   )
 
   if ($PSCmdlet.ParameterSetName -eq 'Credential' -AND $Credential -eq $null) { $Credential = Get-Credential}
@@ -43,6 +44,23 @@ Function Connect-SscServer {
     $username = $Credential.GetNetworkCredential().username
     $password = $Credential.GetNetworkCredential().password
   }
+
+  if ($SkipCertificateCheck) {
+    # This if statement is using example code from https://stackoverflow.com/questions/11696944/powershell-v3-invoke-webrequest-https-error
+    add-type @"
+    using System.Net;
+    using System.Security.Cryptography.X509Certificates;
+    public class TrustAllCertsPolicy : ICertificatePolicy {
+        public bool CheckValidationResult(
+            ServicePoint srvPoint, X509Certificate certificate,
+            WebRequest request, int certificateProblem) {
+            return true;
+        }
+    }
+"@
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12'
+    [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
+  } # end if SkipCertificate Check
   
   $loginBody = @{'username'=$username; 'password'=$password; 'config_name'=$AuthSource}
   try {

--- a/Modules/SaltStackConfig/SaltStackConfig.psm1
+++ b/Modules/SaltStackConfig/SaltStackConfig.psm1
@@ -37,7 +37,7 @@ Function Connect-SscServer {
     [Parameter(Mandatory=$false, Position=3)][string]$AuthSource='internal',
     [Parameter(Mandatory=$false, ParameterSetName='Credential')][PSCredential]$Credential,
     [Parameter(Mandatory=$false)][Switch]$SkipCertificateCheck,
-    [Parameter(Mandatory=$false)][ValidateSet('Tls13','Tls12','Tls11','Tls','SystemDefault')]$SslProtocol
+    [Parameter(Mandatory=$false)][System.Net.SecurityProtocolType]$SslProtocol
   )
 
   if ($PSCmdlet.ParameterSetName -eq 'Credential' -AND $Credential -eq $null) { $Credential = Get-Credential}
@@ -63,7 +63,7 @@ Function Connect-SscServer {
   } # end if SkipCertificate Check
   
   if ($SslProtocol) {
-    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]$SslProtocol
+    [System.Net.ServicePointManager]::SecurityProtocol = $SslProtocol
   }
 
   $loginBody = @{'username'=$username; 'password'=$password; 'config_name'=$AuthSource}


### PR DESCRIPTION
In the previous version of Connect-SscServer, we assumed that the SaltStack Config master node has an SSL certificate from an authority trusted by the powershell client and that the client supports the same TLS version as the server.  However, this may not be the case.  Therefore this commit adds support for a switch parameter named SkipCertificateCheck which ignores untrusted certificates and sets support for various TLS versions.  All SSC servers I've tested with have only supported Tls12, but lower levels were added to this function for backwards compatibility.

Signed-off-by: Brian Wuchner <brian.wuchner@gmail.com>