### PR TITLE
Fixing instances of sort with sort-object

### DIFF
--- a/Modules/DatastoreFunctions/DatastoreFunctions.psm1
+++ b/Modules/DatastoreFunctions/DatastoreFunctions.psm1
@@ -34,7 +34,7 @@ Function Get-HostViews {
 			Throw "No Datastores found.`nIs ""$Datastore"" a Datastore Object?"
 		}
 		$allHosts = @()
-		$DShostsKeys = $allDatastores.extensiondata.host.key.value | sort | get-unique -asstring
+		$DShostsKeys = $allDatastores.extensiondata.host.key.value | sort-object | get-unique -asstring
 		$DShosts = foreach ($thisKey in $DShostsKeys) {($allDatastores.extensiondata.host | ? {$_.key.value -eq $thisKey})[0]}
 		$i = 1
 		foreach ($DSHost in $DSHosts){

--- a/Modules/Get-NewAndRemovedVMs/Get-NewAndRemovedVMs.psm1
+++ b/Modules/Get-NewAndRemovedVMs/Get-NewAndRemovedVMs.psm1
@@ -125,7 +125,7 @@ Begin {
 
 process {
     $result = Get-VIEventPlus -Start ((get-date).adddays(-$Days)) -EventType @("VmCreatedEvent", "VmBeingClonedEvent", "VmBeingDeployedEvent","VmRemovedEvent")
-    $sortedResult = $result | Select CreatedTime, @{N='Cluster';E={$_.ComputeResource.Name}}, @{Name="VMName";Expression={$_.vm.name}}, UserName, @{N='Type';E={$_.GetType().Name}}, FullFormattedMessage | Sort CreatedTime
-    $sortedResult | where {$_.Cluster -like $ClusterName}
+    $sortedResult = $result | Select-Object CreatedTime, @{N='Cluster';E={$_.ComputeResource.Name}}, @{Name="VMName";Expression={$_.vm.name}}, UserName, @{N='Type';E={$_.GetType().Name}}, FullFormattedMessage
+    $sortedResult | where-object {$_.Cluster -like $ClusterName}
 }
 }

--- a/Modules/VAMI/VAMI.psm1
+++ b/Modules/VAMI/VAMI.psm1
@@ -316,8 +316,8 @@ Function Get-VAMIDisks {
     $storageAPI = Get-CisService -Name 'com.vmware.appliance.system.storage'
     $disks = $storageAPI.list()
 
-    foreach ($disk in $disks | sort {[int]$_.disk.toString()}) {
-        $disk | Select Disk, Partition
+    foreach ($disk in $disks | Sort-Object {[int]$_.disk.toString()}) {
+        $disk | Select-Object Disk, Partition
     }
 }
 

--- a/Modules/VMware.VMEncryption/VMware.VMEncryption.psm1
+++ b/Modules/VMware.VMEncryption/VMware.VMEncryption.psm1
@@ -1269,7 +1269,7 @@ Function Get-EntityByCryptoKey {
 
        $VMList += $VMs|Where {$_.EncryptionKeyId|MatchKeys -KeyId $keyId -KMSClusterId $KMSClusterId}
        $VMList += $VMDiskList.Parent
-       $VMList = $VMList|sort|Get-Unique
+       $VMList = $VMList|sort-object|Get-Unique
        $Entities.VMList = $VMList
     }
 

--- a/Modules/Vi-Module/Vi-Module.psm1
+++ b/Modules/Vi-Module/Vi-Module.psm1
@@ -10,7 +10,7 @@ Function Get-RDM {
 .EXAMPLE
 	C:\PS> Get-VM -Server VC1 |Get-RDM
 .EXAMPLE
-	C:\PS> Get-VM |? {$_.Name -like 'linux*'} |Get-RDM |sort VM,Datastore,HDLabel |ft -au
+	C:\PS> Get-VM |? {$_.Name -like 'linux*'} |Get-RDM |sort-object VM,Datastore,HDLabel |ft -au
 .EXAMPLE
 	C:\PS> Get-Datacenter 'North' |Get-VM |Get-RDM |? {$_.HDSizeGB -gt 1} |Export-Csv -NoTypeInformation 'C:\reports\North_RDMs.csv'
 .EXAMPLE
@@ -113,7 +113,7 @@ Function Convert-VmdkThin2EZThick {
 .EXAMPLE
 	C:\PS> Get-VM VM1 |Convert-VmdkThin2EZThick
 .EXAMPLE
-	C:\PS> Get-VM VM1,VM2 |Convert-VmdkThin2EZThick -Confirm:$false |sort VM,Datastore,VMDK |ft -au
+	C:\PS> Get-VM VM1,VM2 |Convert-VmdkThin2EZThick -Confirm:$false |sort-object VM,Datastore,VMDK |ft -au
 .INPUTS
 	[VMware.VimAutomation.ViCore.Types.V1.Inventory.VirtualMachine[]] Objects, returned by Get-VM cmdlet.
 .OUTPUTS
@@ -352,7 +352,7 @@ Function Set-PowerCLiTitle {
 	http://www.ps1code.com/single-post/2015/11/17/ConnectVIServer-deep-dive-or-%C2%ABWhere-am-I-connected-%C2%BB
 #>
 
-$VIS = $global:DefaultVIServers |sort -Descending ProductLine,Name
+$VIS = $global:DefaultVIServers |sort-object -Descending ProductLine,Name
 
 If ($VIS) {
 	Foreach ($VIObj in $VIS) {


### PR DESCRIPTION
Fixes #535 - module using sort instead of sort-object causing unexpected behavior on powershell core/Linux.
Instead of only addressing the issue at hand, I looked for other instances of sort being used instead of sort-object for other modules within this repo and corrected those as well.  I think I got most of them, but feel free to raise another issue if you find another.  If the sort was in an example/help statement, or was inside the logic/process of the function, I replaced sort with sort-object.  In the one case where the sort was only applied to the output I removed the statement -- this way the function user can add the sort in their script and not have to sort output twice.  I changed a couple  select/where with select-object/where-object along the way as well just as I saw them.

Signed-off-by: Brian Wuchner <brian.wuchner@gmail.com>