### PR TITLE
Add vCenter and collaboration support for manul pools

### DIFF
--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -4561,6 +4561,9 @@ function New-HVPool {
       } elseIf ($jsonObject.type -eq "MANUAL") {
         $MANUAL = $true
         $poolType = 'MANUAL'
+	if ($null -ne $jsonObject.ManualDesktopSpec.VirtualCenter) {
+          $vCenter = $jsonObject.ManualDesktopSpec.VirtualCenter
+        }
         $userAssignment = $jsonObject.ManualDesktopSpec.userAssignment.userAssignment
         $automaticAssignment = $jsonObject.ManualDesktopSpec.userAssignment.AutomaticAssignment
         $source = $jsonObject.ManualDesktopSpec.source

--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -3857,6 +3857,9 @@ function New-HVPool {
     [int]$refreshThresholdPercentageForReplicaOsDisk,
 
     #DesktopDisplayProtocolSettings
+    [Parameter(Mandatory = $false,ParameterSetName = 'MANUAL')]
+    [boolean]$enableCollaboration = $true,
+    
     #desktopSpec.desktopSettings.logoffSettings.supportedDisplayProtocols
     [Parameter(Mandatory = $false,ParameterSetName = 'FULL_CLONE')]
     [Parameter(Mandatory = $false,ParameterSetName = 'INSTANT_CLONE')]
@@ -4626,6 +4629,7 @@ function New-HVPool {
                 $maxResolutionOfAnyOneMonitor = $jsonObject.DesktopSettings.displayProtocolSettings.pcoipDisplaySettings.maxResolutionOfAnyOneMonitor
               }
               $enableHTMLAccess = $jsonObject.DesktopSettings.displayProtocolSettings.enableHTMLAccess
+	      $enableCollaboration = $jsonObject.DesktopSettings.displayProtocolSettings.EnableCollaboration
             }
 
             if ($null -ne $jsonObject.DesktopSettings.mirageConfigurationOverrides) {
@@ -4934,6 +4938,7 @@ function New-HVPool {
             $desktopDisplayProtocolSettings.getDataObject().SupportedDisplayProtocols = $supportedDisplayProtocols
             $desktopDisplayProtocolSettings.setDefaultDisplayProtocol($defaultDisplayProtocol)
             $desktopDisplayProtocolSettings.setEnableHTMLAccess($enableHTMLAccess)
+	    $desktopDisplayProtocolSettings.setEnableCollaboration($enableCollaboration)
             $desktopDisplayProtocolSettings.setAllowUsersToChooseProtocol($allowUsersToChooseProtocol)
 
             $desktopPCoIPDisplaySettings = $desktopSettingsService.getDesktopPCoIPDisplaySettingsHelper()


### PR DESCRIPTION
1. Currently when there are multiple vCenters  for the broker, running New-HVPool with spec json file to create a manual pool would fail complaining "Get-VcenterID : Multiple Vcenter servers found, please specify the vCenter Name" even those the it was set in the configuration file. This could be resolved by accepting "virtualCenter" property for manual pools as others.
2. Adding support to enable collaborations for manual pools. To resolve it, we can have "$jsonObject.DesktopSettings.displayProtocolSettings.EnableCollaboration" accepted for manual pools.
  