### PR TITLE
Updated the SsoAdmin projects to reference WCF from the framework instead of a package.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 #VS Code Files
 *.vscode
+/.vs
 
 # Windows image file caches
 Thumbs.db

--- a/Modules/VMware.vSphere.SsoAdmin/src/VMware.vSphere.SsoAdmin.Client/VMware.vSphere.LsClient/VMware.vSphere.LsClient.csproj
+++ b/Modules/VMware.vSphere.SsoAdmin/src/VMware.vSphere.SsoAdmin.Client/VMware.vSphere.LsClient/VMware.vSphere.LsClient.csproj
@@ -9,11 +9,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <Reference Include="System.IdentityModel" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0" />
-    <PackageReference Include="System.ServiceModel.Duplex" Version="4.4.0" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.4.0" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.0" />
-    <PackageReference Include="System.ServiceModel.Security" Version="4.4.0" />
+    <Reference Include="System.ServiceModel" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/Modules/VMware.vSphere.SsoAdmin/src/VMware.vSphere.SsoAdmin.Client/VMware.vSphere.SsoAdmin.Utils/VMware.vSphere.SsoAdmin.Utils.csproj
+++ b/Modules/VMware.vSphere.SsoAdmin/src/VMware.vSphere.SsoAdmin.Client/VMware.vSphere.SsoAdmin.Utils/VMware.vSphere.SsoAdmin.Utils.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RootNamespace>VMware.vSphere.SsoAdmin.Utils</RootNamespace>
@@ -9,11 +9,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <Reference Include="System.IdentityModel" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0" />
-    <PackageReference Include="System.ServiceModel.Duplex" Version="4.4.0" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.4.0" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.0" />
-    <PackageReference Include="System.ServiceModel.Security" Version="4.4.0" />
+    <Reference Include="System.ServiceModel" />
     <PackageReference Include="Microsoft.PowerShell.5.ReferenceAssemblies" Version="1.0.0" />
   </ItemGroup>
   

--- a/Modules/VMware.vSphere.SsoAdmin/src/VMware.vSphere.SsoAdmin.Client/VMware.vSphere.SsoAdminClient/VMware.vSphere.SsoAdminClient.csproj
+++ b/Modules/VMware.vSphere.SsoAdmin/src/VMware.vSphere.SsoAdmin.Client/VMware.vSphere.SsoAdminClient/VMware.vSphere.SsoAdminClient.csproj
@@ -17,11 +17,7 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <Reference Include="System.IdentityModel" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0" />
-    <PackageReference Include="System.ServiceModel.Duplex" Version="4.4.0" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.4.0" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.0" />
-    <PackageReference Include="System.ServiceModel.Security" Version="4.4.0" />
+    <Reference Include="System.ServiceModel" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">


### PR DESCRIPTION
Updated the SsoAdmin projects to reference WCF from the framework instead of a package.

The package references were giving a false impression that the code was using a fixed version of WCF while in reality the version used is the one from the framework that the user have installed.