### PR TITLE
Updating module to resolve duplicate object bug

### DIFF
--- a/Modules/VMware.Skyline.InsightsApi/VMware.Skyline.InsightsApi.psd1
+++ b/Modules/VMware.Skyline.InsightsApi/VMware.Skyline.InsightsApi.psd1
@@ -17,7 +17,7 @@ SPDX-License-Identifier: BSD-2-Clause
 RootModule = 'VMware.Skyline.InsightsApi.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.0'
+ModuleVersion = '1.0.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Modules/VMware.Skyline.InsightsApi/VMware.Skyline.InsightsApi.psm1
+++ b/Modules/VMware.Skyline.InsightsApi/VMware.Skyline.InsightsApi.psm1
@@ -237,10 +237,9 @@ Function Get-SkylineFinding {
 
             # Try to get results the first time
             $results = @()
-            $thisQueryBody = $queryBody -Replace 'filter: {}', "filter: { $filterString }"
             $thisIteration = 0
             do {
-                $thisQueryBody = $thisQueryBody -Replace 'start: 0', "start: $thisIteration"
+                $thisQueryBody = $queryBody -Replace 'filter: {}', "filter: { $filterString }" -Replace 'start: 0', "start: $thisIteration"
                 Write-Debug $thisQueryBody
                 $thisResult = Invoke-SkylineInsightsApi -queryBody (@{'query' = $thisQueryBody} | ConvertTo-Json -Compress)
                 $totalRecords = $thisResult.data.activeFindings.totalRecords
@@ -325,13 +324,11 @@ Function Get-SkylineAffectedObject {
     }
 
     process {
-        $thisQueryBody = $queryBody -Replace 'findingId: "",', "findingId: `"$findingId`","
         foreach ( $thisProduct in $products ) {
             $thisIteration = 0
             $results = @() # reset results variable between products
             do {
-                $thisQueryBody = $thisQueryBody -Replace 'product: "",', "product: `"$thisProduct`","
-                $thisQueryBody = $thisQueryBody -Replace 'start: 0', "start: $thisIteration"
+                $thisQueryBody = $queryBody -Replace 'product: "",', "product: `"$thisProduct`"," -Replace 'start: 0', "start: $thisIteration" -Replace 'findingId: "",', "findingId: `"$findingId`","
                 Write-Debug $thisQueryBody
                 $thisResult = Invoke-SkylineInsightsApi -queryBody (@{'query' = $thisQueryBody} | ConvertTo-Json -Compress)
                 $totalRecords = $thisResult.data.activeFindings.Findings.totalAffectedObjectsCount


### PR DESCRIPTION
When passing in objects to Get-SkylineAffectedObject, it was possible for duplicate queries to be invoked for the same product.  This commit fixes that by moving some of the string manipulation inside the correct loop for this function.  Additionally, the text replace lines were consolidated to reduce some confusion with variable assignment that led to this bug in the first place.

Signed-off-by: Brian Wuchner <brian.wuchner@gmail.com>