### PR TITLE
Fix the bug of not creating certificates in linux

### DIFF
--- a/Modules/VMware.vSphere.SsoAdmin/src/VMware.vSphere.SsoAdmin.Client/VMware.vSphere.SsoAdminClient/SsoAdminClient.cs
+++ b/Modules/VMware.vSphere.SsoAdmin/src/VMware.vSphere.SsoAdmin.Client/VMware.vSphere.SsoAdminClient/SsoAdminClient.cs
@@ -1305,7 +1305,7 @@ namespace VMware.vSphere.SsoAdminClient
                         if (externalDomain.details?.certificates != null && externalDomain.details?.certificates.Length > 0) {
                             var certificatesList = new List<X509Certificate2>();
                             foreach (var cert in externalDomain.details?.certificates) {
-                                certificatesList.Add(new X509Certificate2(Encoding.ASCII.GetBytes(cert)));
+                                certificatesList.Add(new X509Certificate2(Convert.FromBase64String(cert)));
                             }
                            extIdentitySource.Certificates = certificatesList.ToArray();
                         }


### PR DESCRIPTION
Problem: `certificatesList.Add(new X509Certificate2(Encoding.ASCII.GetBytes(cert)))` caused ANS1 Corrupted Data error in Linux. `Encoding.ASCII.GetBytes()` is to get the ASCII byte representation of the base64 string, not decoding the base64 string. It might work with Windows but not Linux. This problem was also tracked in https://github.com/dotnet/runtime/issues/47005.

Solution: replaced it with `new X509Certificate2(Convert.FromBase64String(cert))`