### PR TITLE
Update VMware.HV.Helper.psm1

### DIFF
--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -731,7 +731,7 @@ function Connect-HVEvent {
         Write-Error "Unsupported type recieved for dbPassword: [$dbPassword]. dbpassword should SecureString type."
 	    break
       }
-      $connectionString = "Data Source=$dbServer, $dbPort; Initial Catalog=$dbName;"
+      $connectionString = "Data Source=$dbServer, $dbPort; Initial Catalog=$dbName; multiSubnetFailover=True"
       $connection = New-Object System.Data.SqlClient.SqlConnection ($connectionString)
       $password.MakeReadOnly()
       $connection.Credential = New-Object System.Data.SqlClient.SqlCredential($dbUserName, $password);


### PR DESCRIPTION
Added `multiSubnetFailover` keyword with value `True` to `ConnectionString` proprety of `SqlConnection` class to support failover MSSQL clusters