### PR TITLE
VMWare.HV.Helper - New-HVPool: implemented vGPU profile for instant clones

### DIFF
--- a/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
+++ b/Modules/VMware.Hv.Helper/VMware.HV.Helper.psm1
@@ -4990,7 +4990,6 @@ function New-HVPool {
             $desktopPCoIPDisplaySettings.setRenderer3D($renderer3D)
             #setEnableGRIDvGPUs is not exists, because this property cannot be updated.
             $desktopPCoIPDisplaySettings.getDataObject().EnableGRIDvGPUs = $enableGRIDvGPUs
-            $desktopPCoIPDisplaySettings.getDataObject().EnableGRIDvGPUs = $enableGRIDvGPUs
             if ($enableGRIDvGPUs -eq $true -and $renderer3D -ne 'MANAGE_BY_VSPHERE_CLIENT' -and $InstantClone -eq $true) {
               Write-Error "Enabling GRID support requires that 3D rendering be managed by the vSphere client"
               break


### PR DESCRIPTION
when creating an instant clone, the new-hvpool command was unable to create a hvpool with a nvidia grid gpu profile.

Since we are only deploying instant clone desktop pools, we are unable to test other types. I have commented out the other parameter sets besides INSTANT_CLONE.

Closes #622 